### PR TITLE
Emit Resource and Memory Usage Information - DEV-2232

### DIFF
--- a/source/web-service/startup.py
+++ b/source/web-service/startup.py
@@ -3,6 +3,7 @@
 import sys
 import datetime
 import os
+import psutil
 
 # os.environ["MART_LOD_BASE_URL"] = "http://localhost:5100"
 
@@ -64,3 +65,56 @@ def welcome():
 	body = sprintf("Welcome to the Museum Linked Art Data Service at %02d:%02d:%02d on %02d/%02d/%04d" % (now.hour, now.minute, now.second, now.month, now.day, now.year))
 	
 	return Response(body, status=200)
+
+@app.before_request
+def beforeRequest():
+	debug("%s - beforeRequest() called..." % (__file__), level=1)
+
+@app.after_request
+def afterRequest(response):
+	"""The after_request decorator allows us to augment responses after the request has completed, but before the response is returned to the client."""
+	
+	debug("%s - afterRequest() called... response.headers = %s" % (__file__, type(response.headers)), level=1)
+	
+	database = DI.get("database")
+	if(not database):
+		debug("No database connection could be established!", error=True)
+		return response
+	
+	information = database.information()
+	if(not isinstance(information, dict)):
+		debug("No database information could be obtained!", error=True)
+		return response
+	
+	process = psutil.Process()
+	if(not process):
+		debug("No process information instance could be obtained!", error=True)
+		return response
+	
+	information["process"] = {
+		"id": os.getpid(),
+		"memory": {
+			"info": process.memory_full_info(),
+			"used": process.memory_full_info().uss,
+		}
+	}
+	
+	debug(information, format="JSON", label="Process Information", level=2)
+	
+	if(os.getenv("MART_WEB_DEBUG_HEADER", "NO") == "YES"):
+		# Obtain the headers
+		headers = response.headers
+		if(not headers):
+			debug("No response headers could be obtained!", error=True)
+			return response
+		
+		headers["X-Process-Information"] = json.dumps(information)
+		
+		# Adjust the headers
+		response.headers = headers
+	
+	return response
+
+@app.teardown_request
+def teardownRequest(response):
+	debug("%s - teardownRequest() called..." % (__file__), level=1)


### PR DESCRIPTION
Added code to support emitting resource and memory usage information during each request so that usage can be monitored over time for debugging purposes to evaluate how usage changes over a time and over API requests. Support relies on ‘psutil’ standard library for gathering memory usage of the current process, and support added to the database hander class to obtain database connection and resource usage information.