### PR TITLE
Raise RuntimeError Upon Database Connection Failure - DEV-2238

### DIFF
--- a/source/transformer/startup.py
+++ b/source/transformer/startup.py
@@ -50,7 +50,7 @@ connection = database.connect(autocommit=False)
 if(connection):
 	di.set("connection", connection)
 else:
-	raise RuntimeError("No database connection could not be established!")
+	raise RuntimeError("The database connection could not be established!")
 
 # Import the transformers
 from app.transformers import *

--- a/source/web-service/startup.py
+++ b/source/web-service/startup.py
@@ -36,8 +36,12 @@ from app.database import Database
 # Initialise the dependency injector
 di = DI()
 
-# Instantiate and register the database service
-di.set("database", Database(shared=False))
+# Instantiate and register the database handler
+database = Database(shared=False)
+if(database):
+	di.set("database", database)
+else:
+	raise RuntimeError("The database handler could not be initialized!")
 
 # Instantiate and register the graph store service
 # di.set("graph", GraphStore(shared=False))


### PR DESCRIPTION
On the off-chance that a database connection failure occurs, raise a RuntimeError to clearly report the issue rather than continuing without a connection. Also unified the database connection RuntimeError wording between the transformer and web services for clarity.