### PR TITLE
Fix Constituent Nationality Mapping - DEV-2181

### DIFF
--- a/source/transformer/app/transformers/museum/collection/ConstituentTransformer.py
+++ b/source/transformer/app/transformers/museum/collection/ConstituentTransformer.py
@@ -165,7 +165,7 @@ class ConstituentTransformer(BaseTransformer):
 			classification = get(nationality, "classification")
 			if(classification):
 				type = Type()
-				type.id = get(classification, "uri")
+				type.id = get(classification, "id")
 				type._label = get(classification, "label")
 				type.classified_as = Type(ident="http://vocab.getty.edu/aat/300379842", label="Nationality")
 				


### PR DESCRIPTION
Fix Constituent (Person/Group) nationality mapping, to resolve issue where the AAT ID URL was absent from the generated classification.