### PR TITLE
Store Transformer Manager Instance for Later Use - DEV-2499

### DIFF
--- a/source/transformer/startup.py
+++ b/source/transformer/startup.py
@@ -72,7 +72,11 @@ if(options["manager"] in ["records"]):
 else:
 	manager = ActivityStreamManager()
 
-if(manager):
+if(isinstance(manager, BaseManager)):
+	debug("The %s has been instantiated..." % (manager), level=1)
+	
+	DI.set("manager", manager)
+	
 	if(isinstance(manager, RecordsManager)): # manual/automatic records manager
 		manager.process(**options)
 	else: # automatic (activity streams polling) transform mode


### PR DESCRIPTION
Store the transformer manager instance using the dependency injector (DI) for later use; this helps support storage of entities generated out-of-bounds by enabling access to the transformer manager instance and its methods, such as the storeEntity method.