### PR TITLE
Removed Inhabited Place AAT Term References – DEV-2588

### DIFF
--- a/source/transformer/app/transformers/museum/collection/ArtifactTransformer.py
+++ b/source/transformer/app/transformers/museum/collection/ArtifactTransformer.py
@@ -516,9 +516,6 @@ class ArtifactTransformer(BaseTransformer):
 				
 				place.identified_by = name
 				
-				# Map the "Inhabited Place" classification
-				place.classified_as = Type(ident="http://vocab.getty.edu/aat/300008347", label="Inhabited Place")
-				
 				visual.represents = place
 				
 				entity.shows = visual
@@ -858,9 +855,6 @@ class ArtifactTransformer(BaseTransformer):
 						
 						# Map the place name
 						place.identified_by = name
-						
-						# Map the "Inhabited Place" classification
-						place.classified_as = Type(ident="http://vocab.getty.edu/aat/300008347", label="Inhabited Place")
 						
 						production.took_place_at = place
 					

--- a/source/transformer/app/transformers/museum/collection/ConstituentTransformer.py
+++ b/source/transformer/app/transformers/museum/collection/ConstituentTransformer.py
@@ -104,8 +104,6 @@ class ConstituentTransformer(BaseTransformer):
 					name.content = value
 					place.identified_by = name
 					
-					place.classified_as = Type(ident="http://vocab.getty.edu/aat/300008347", label="Inhabited Place")
-					
 					birth.took_place_at = place
 					
 					entity.born = birth
@@ -137,8 +135,6 @@ class ConstituentTransformer(BaseTransformer):
 					name.id = self.generateEntityURI(sub=["death", "place", "name"])
 					name.content = value
 					place.identified_by = name
-					
-					place.classified_as = Type(ident="http://vocab.getty.edu/aat/300008347", label="Inhabited Place")
 					
 					death.took_place_at = place
 					


### PR DESCRIPTION
Removed Inhabited Place AAT Term References from Artifact and Constituent transformers. In the future once additional data reconciliation has been conducted on our source data, we could add more specific place classifications that carry more meaning, such as City or Country, etc.