### PR TITLE
Removed Incorrect Dimensions Statement AAT Term – DEV-2593

### DIFF
--- a/source/transformer/app/transformers/museum/collection/ArtifactTransformer.py
+++ b/source/transformer/app/transformers/museum/collection/ArtifactTransformer.py
@@ -739,9 +739,6 @@ class ArtifactTransformer(BaseTransformer):
 					lobj.id = self.generateEntityURI(sub=["dimensions", id])
 					lobj.content = statement
 					
-					# Map the "Dimension Statement" classification
-					lobj.classified_as = Type(ident="http://vocab.getty.edu/aat/300266036", label="Dimension Statement")
-
 					# Map the “Dimensions Description" classification
 					lobj.classified_as = Type(ident="http://vocab.getty.edu/aat/300435430", label="Dimensions Description")
 					


### PR DESCRIPTION
Removed the incorrect “dimensions statement” AAT term (300266036), which actually references the broader concept of “dimensions (measurements)”. This is now replaced by the correct “dimensions description” AAT term (300435430).