### PR TITLE
Removed Incorrect Materials AAT Term – DEV-2594

### DIFF
--- a/source/transformer/app/transformers/museum/collection/ArtifactTransformer.py
+++ b/source/transformer/app/transformers/museum/collection/ArtifactTransformer.py
@@ -361,9 +361,6 @@ class ArtifactTransformer(BaseTransformer):
 				lobj.id = self.generateEntityURI(sub=["material-statement", id])
 				lobj.content = medium
 				
-				# Map the "Material Statement" classification
-				lobj.classified_as = Type(ident="http://vocab.getty.edu/aat/300010358", label="Material Statement")
-
 				# Map the “Materials Description" classification
 				lobj.classified_as = Type(ident="http://vocab.getty.edu/aat/300435429", label="Materials Description")
 				


### PR DESCRIPTION
Removed the incorrect “materials statement” AAT term (300010358), which actually references the broader concept of “materials (substances)”. This is now replaced by the correct “materials description” AAT term (300435429).