### PR TITLE
Removed Signatures (Names) AAT Term – DEV-2595

### DIFF
--- a/source/transformer/app/transformers/museum/collection/ArtifactTransformer.py
+++ b/source/transformer/app/transformers/museum/collection/ArtifactTransformer.py
@@ -456,11 +456,8 @@ class ArtifactTransformer(BaseTransformer):
 						lobj.id = self.generateEntityURI(sub=["signature", id])
 						lobj.content = value
 						
-						# Map the "Signatures (Names)" classification
-						lobj.classified_as = Type(ident="http://vocab.getty.edu/aat/300028705", label="Signatures (Names)")
-
 						# Map the “Signatures Description" classification
-						lobj.classified_as = Type(ident="http://vocab.getty.edu/aat/300435415", label="Signature Description")
+						lobj.classified_as = Type(ident="http://vocab.getty.edu/aat/300435415", label="Signatures Description")
 						
 						# Map the "Brief Text" classification
 						lobj.classified_as = Type(ident="http://vocab.getty.edu/aat/300418049", label="Brief Text")


### PR DESCRIPTION
Removed “Signatures (Names)” AAT term (300028705) as this is now superseded by the new and specific “Signatures Description” AAT term (300435415)