### PR TITLE
Adjust Current Owner Reference – DEV-2608

### DIFF
--- a/source/transformer/app/transformers/museum/__init__.py
+++ b/source/transformer/app/transformers/museum/__init__.py
@@ -19,15 +19,12 @@ class BaseTransformer(SharedBaseTransformer):
 	
 	# Create J. Paul Getty Museum Group Entity
 	def createGettyMuseumGroup(self):
-		JPGT = self.createGettyTrustGroup()
-		
 		JPGM = Group()
-		JPGM.id = "http://vocab.getty.edu/ulan/500115988"
-		JPGM._label = "J. Paul Getty Museum, Los Angeles, California"
-		JPGM.classified_as = Type(ident="http://vocab.getty.edu/aat/300312281", label="Museum")
 		
-		# Note that the Museum is a "member_of" (part of) the Trust
-		JPGM.member_of = JPGT
+		# The UUID c496a7b4-6087-4deb-a1ac-0f21bd3fd87b corresponds to the J. Paul Getty Museum TMS/DOR Constituent
+		JPGM.id = self.generateEntityURI(entity=Group, id="c496a7b4-6087-4deb-a1ac-0f21bd3fd87b")
+		
+		JPGM._label = "J. Paul Getty Museum, Los Angeles, California"
 		
 		# Return a copy of the Group so it can be modified without affecting the source
 		return copy.copy(JPGM)


### PR DESCRIPTION
Adjusted `current_owner` reference to point to the J. Paul Getty Museum `Group` record via its UUID `c496a7b4-6087-4deb-a1ac-0f21bd3fd87b`, rather than directly via its ULAN ID `500115988`. The `Group` record instead references the ULAN ID via it’s `exact_match` property.