### PR TITLE
Removed Object's CurrentKeeper's MemberOf Property – DEV-2626

### DIFF
--- a/source/transformer/app/transformers/museum/collection/ArtifactTransformer.py
+++ b/source/transformer/app/transformers/museum/collection/ArtifactTransformer.py
@@ -633,9 +633,6 @@ class ArtifactTransformer(BaseTransformer):
 				group.id = self.generateEntityURI(entity=Group, UUID=id)
 				group._label = value + " (Curatorial Department)"
 				
-				# Obtain a copy of the J. Paul Getty Museum Group
-				group.member_of = self.createGettyMuseumGroup(); # defined in BaseTransformer.py
-				
 				# Map the "Department (Organizational Unit)" classification
 				group.classified_as = Type(ident="http://vocab.getty.edu/aat/300263534", label="Department (Organizational Unit)");
 				


### PR DESCRIPTION
Removed the `Object` entity’s `current_keeper` `member_of` property as this will instead be mapped within the `current_keeper` entity’s related `Group` or `Person` record.