### PR TITLE
Timeout for Requests – DEV-2606

### DIFF
--- a/source/transformer/app/manager/__init__.py
+++ b/source/transformer/app/manager/__init__.py
@@ -68,7 +68,7 @@ class BaseManager(ABC):
 		# debug(options, format="JSON", label="options")
 		# debug(headers, format="JSON", label="headers")
 		
-		response = requests.get(URL, headers=headers)
+		response = requests.get(URL, headers=headers, timeout=90)
 		if(isinstance(response, requests.models.Response)):
 			if(response.status_code == 200):
 				data = response.text

--- a/source/transformer/app/transformers/__init__.py
+++ b/source/transformer/app/transformers/__init__.py
@@ -398,7 +398,7 @@ class BaseTransformer(ABC):
 		if(isinstance(URL, str)):
 			headers = self.assembleHeaders()
 			if(isinstance(headers, dict)):
-				response = requests.get(URL, headers=headers)
+				response = requests.get(URL, headers=headers, timeout=90)
 				if(response):
 					if(response.status_code == 200):
 						data = json.loads(response.text)

--- a/source/transformer/app/transformers/museum/collection/BaseTransformer.py
+++ b/source/transformer/app/transformers/museum/collection/BaseTransformer.py
@@ -182,7 +182,7 @@ class BaseTransformer(SharedMuseumBaseTransformer):
 			
 			headers = self.assembleHeaders()
 			if(isinstance(headers, dict)):
-				response = requests.get(URL, headers=headers)
+				response = requests.get(URL, headers=headers, timeout=90)
 				if(isinstance(response, requests.models.Response)):
 					if(response.status_code == 200):
 						if(isinstance(response.text, str) and len(response.text) > 0):


### PR DESCRIPTION
Added 90 sec timeout for 'requests.get()' function. Will apply to both: 'connect' and 'read'.