### PR TITLE
Added CA Root Certificates to Docker Containers – DEV-2771

### DIFF
--- a/source/transformer/Dockerfile
+++ b/source/transformer/Dockerfile
@@ -6,6 +6,9 @@ LABEL Authors="Daniel Sissman <dsissman@getty.edu>, Viktor Grabarchuk <vgrabarch
 # Set our working directory
 WORKDIR /
 
+# Install ca-certificates so that SSL/TLS can function from within the container
+RUN apt-get update && apt-get -y install ca-certificates
+
 # Later in preparation for deploying our container we need to integrate and test with envconsul...
 # COPY --from=getty/envconsul:latest /bin/envconsul /usr/local/bin/envconsul
 # COPY --from=getty/envconsul:latest /usr/local/bin/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh

--- a/source/web-service/Dockerfile
+++ b/source/web-service/Dockerfile
@@ -6,6 +6,9 @@ LABEL Authors="Daniel Sissman <dsissman@getty.edu>, Viktor Grabarchuk <vgrabarch
 # Set our working directory
 WORKDIR /
 
+# Install ca-certificates so that SSL/TLS can function from within the container
+RUN apt-get update && apt-get -y install ca-certificates
+
 # Later in preparation for deploying our container we need to integrate and test with envconsul...
 # COPY --from=getty/envconsul:latest /bin/envconsul /usr/local/bin/envconsul
 # COPY --from=getty/envconsul:latest /usr/local/bin/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh


### PR DESCRIPTION
Added missing CA root certificates to Docker containers to provide support for connecting to SSL/TLS protected endpoints.