### PR TITLE
Use HTTP vs HTTPS for Neptune – DEV-2772

### DIFF
--- a/source/app/graph/__init__.py
+++ b/source/app/graph/__init__.py
@@ -39,7 +39,7 @@ class GraphStore:
 		if(isinstance(cls.configuration["port"], str) and len(cls.configuration["port"]) > 0):
 			endpoint += ":" + cls.configuration["port"]
 		
-		return sprintf("https://%s/sparql" % (endpoint))
+		return sprintf("http://%s/sparql" % (endpoint))
 	
 	@classmethod
 	def query(cls, query):


### PR DESCRIPTION
Updated the endpoint construction method for Neptune to build a URL based on HTTP vs HTTPS, as HTTPS connections are currently unsupported.