### PR TITLE
Ensure TimeSpan Dates Use xsd:Date Format – DEV-2610

### DIFF
--- a/source/app/utilities/__init__.py
+++ b/source/app/utilities/__init__.py
@@ -241,6 +241,18 @@ def date(format=None, timestamp=None, **kwargs):
 	
 	# debug("date() format = %s" % (format))
 	
+	if("date" in kwargs and isinstance(kwargs["date"], str)):
+		if("format_for_input_date" in kwargs and isinstance(kwargs["format_for_input_date"], str)):
+			format_for_input_date = kwargs["format_for_input_date"]
+		else:
+			format_for_input_date = format
+		
+		try:
+			timestamp = datetime.strptime(kwargs["date"], format_for_input_date)
+		except Exception as e:
+			debug("Exception thrown (%s) while converting date string (%s) with format (%s) to timestamp!" % (str(e), kwargs["date"], format_for_input_date), error=True)
+			return None
+	
 	if(timestamp):
 		now = timestamp
 	else:

--- a/source/transformer/app/transformers/museum/collection/ArtifactTransformer.py
+++ b/source/transformer/app/transformers/museum/collection/ArtifactTransformer.py
@@ -2,7 +2,7 @@ import os
 import json
 
 # Import our application utility functions
-from app.utilities import get, has, debug, sprintf, hyphenatedStringFromSpacedString
+from app.utilities import get, has, debug, sprintf, date, hyphenatedStringFromSpacedString
 
 # Import our Museum Collection BaseTransformer class
 from app.transformers.museum.collection.BaseTransformer import BaseTransformer
@@ -789,11 +789,11 @@ class ArtifactTransformer(BaseTransformer):
 		makers = get(data, "display.makers")
 		if(makers and len(makers) > 0):
 			# Obtain the Object's Date
-			date = get(data, "display.date")
+			dates = get(data, "display.date")
 			# debug(date, format="JSON")
 			
 			# Obtain the Object's Place Created (if available)
-			created = get(data, "display.places.created")
+			created = get(dates, "display.places.created")
 			# debug(created, format="JSON")
 			
 			for maker in makers:
@@ -806,31 +806,31 @@ class ArtifactTransformer(BaseTransformer):
 					person.id = self.generateEntityURI(entity=Person, UUID=id)
 					person._label = value
 					
-					if(date):
+					if(dates):
 						# Add a Name to the TimeSpan of the Prodction activity to store the display date string
 						name = Name();
 						name.id = self.generateEntityURI(sub=["activity", "production", id, "timespan", "name"])
 						name._label = "Date"
-						name.content = get(date, "display.value")
+						name.content = get(dates, "display.value")
 						
 						timespan = TimeSpan()
 						timespan.id = self.generateEntityURI(sub=["activity", "production", id, "timespan"])
 						timespan.identified_by = name
 						
 						# Get the padded lower and upper date values
-						lower = get(date, "value.lower")
-						upper = get(date, "value.upper")
+						lower = get(dates, "value.lower")
+						upper = get(dates, "value.upper")
 						
 						# Clarify if we should treat "begin_of_the_begin" and "end_of_the_begin"
 						# or "begin_of_the_end" and "end_of_the_end" differently than we do below
 						
 						if(lower):
-							timespan.begin_of_the_begin = lower
-							timespan.end_of_the_begin   = lower
+							timespan.begin_of_the_begin = date(format="%Y-%m-%dT%H:%M:%S", date=lower, format_for_input_date="%Y-%m-%d %H:%M:%S")
+							timespan.end_of_the_begin   = date(format="%Y-%m-%dT%H:%M:%S", date=lower, format_for_input_date="%Y-%m-%d %H:%M:%S")
 						
 						if(upper):
-							timespan.begin_of_the_end   = upper
-							timespan.end_of_the_end     = upper
+							timespan.begin_of_the_end   = date(format="%Y-%m-%dT%H:%M:%S", date=upper, format_for_input_date="%Y-%m-%d %H:%M:%S")
+							timespan.end_of_the_end     = date(format="%Y-%m-%dT%H:%M:%S", date=upper, format_for_input_date="%Y-%m-%d %H:%M:%S")
 					
 					# Create the Production activity instance
 					production = Production()

--- a/source/transformer/app/transformers/museum/collection/ConstituentTransformer.py
+++ b/source/transformer/app/transformers/museum/collection/ConstituentTransformer.py
@@ -1,5 +1,5 @@
 # Import our application utility functions
-from app.utilities import get, has, debug
+from app.utilities import get, has, debug, date
 
 # Import our Museum Collection BaseTransformer class
 from app.transformers.museum.collection.BaseTransformer import BaseTransformer
@@ -83,12 +83,12 @@ class ConstituentTransformer(BaseTransformer):
 				birth = Birth()
 				birth.id = self.generateEntityURI(sub=["birth", "activity"])
 				
-				date = get(data, "display.places.birth.date.iso")
-				if(date):
+				date_birth = get(data, "display.places.birth.date.iso")
+				if(date_birth):
 					timespan = TimeSpan()
 					timespan.id = self.generateEntityURI(sub=["birth", "timespan"])
-					timespan.begin_of_the_begin = date
-					timespan.end_of_the_begin   = date
+					timespan.begin_of_the_begin = date(format="%Y-%m-%dT%H:%M:%S", date=date_birth, format_for_input_date="%Y-%m-%d %H:%M:%S")
+					timespan.end_of_the_begin   = date(format="%Y-%m-%dT%H:%M:%S", date=date_birth, format_for_input_date="%Y-%m-%d %H:%M:%S")
 					birth.timespan = timespan
 				
 				value = get(data, "display.places.birth.display.value")
@@ -115,12 +115,12 @@ class ConstituentTransformer(BaseTransformer):
 				death = Death()
 				death.id = self.generateEntityURI(sub=["death", "activity"])
 				
-				date = get(data, "display.places.death.date.iso")
-				if(date):
+				date_death = get(data, "display.places.death.date.iso")
+				if(date_death):
 					timespan = TimeSpan()
 					timespan.id = self.generateEntityURI(sub=["death", "timespan"])
-					timespan.begin_of_the_begin = date
-					timespan.end_of_the_begin   = date
+					timespan.begin_of_the_begin = date(format="%Y-%m-%dT%H:%M:%S", date=date_death, format_for_input_date="%Y-%m-%d %H:%M:%S")
+					timespan.end_of_the_begin   = date(format="%Y-%m-%dT%H:%M:%S", date=date_death, format_for_input_date="%Y-%m-%d %H:%M:%S")
 					death.timespan = timespan
 				
 				value = get(data, "display.places.death.display.value")

--- a/source/transformer/app/transformers/museum/collection/ExhibitionTransformer.py
+++ b/source/transformer/app/transformers/museum/collection/ExhibitionTransformer.py
@@ -1,5 +1,5 @@
 # Import our application utility functions
-from app.utilities import get, has, debug, sprintf
+from app.utilities import get, has, debug, sprintf, date
 
 # Import our dependency injector
 from app.di import DI
@@ -107,16 +107,17 @@ class ExhibitionTransformer(BaseTransformer):
 					
 					began = get(dates, "range.began.values.iso")
 					if(began):
-						timespan.begin_of_the_begin = began
+						timespan.begin_of_the_begin = date(format="%Y-%m-%dT%H:%M:%S", date=began, format_for_input_date="%Y-%m-%d")
 					
 					ended = get(dates, "range.ended.values.iso")
 					if(ended):
-						timespan.end_of_the_end = ended
+						timespan.end_of_the_end = date(format="%Y-%m-%dT%H:%M:%S", date=ended, format_for_input_date="%Y-%m-%d")
 					
 					travelling.timespan = timespan
 			
 			for venue in venues:
-				# debug(venue, format="JSON")
+				# 
+				debug(venue, format="JSON")
 				
 				# Create a venue exhibition activity instance for each venue
 				activity = Activity(ident=self.generateEntityURI(entity=Activity, UUID=get(venue, "activity.uuid")))
@@ -133,11 +134,11 @@ class ExhibitionTransformer(BaseTransformer):
 					
 					began = get(dates, "range.began.values.iso")
 					if(began):
-						timespan.begin_of_the_begin = began
+						timespan.begin_of_the_begin = date(format="%Y-%m-%dT%H:%M:%S", date=began, format_for_input_date="%Y-%m-%d")
 					
 					ended = get(dates, "range.ended.values.iso")
 					if(ended):
-						timespan.end_of_the_end = ended
+						timespan.end_of_the_end = date(format="%Y-%m-%dT%H:%M:%S", date=ended, format_for_input_date="%Y-%m-%d")
 					
 					activity.timespan = timespan
 				


### PR DESCRIPTION
Added support to `utilities.date()` method to support generating a `timestamp` from an string `date` as input, so that string-based dates can be reformatted from their ISO standard formats as obtained from upstream, to the xsd:Date format needed for LOD, in the `ArtifactTransformer`, `ConstituentTransformer` and `ExhibitionTransformer` mappings.