### PR TITLE
Adjust Custom Term Base URLs – DEV-2605

### DIFF
--- a/source/transformer/app/transformers/museum/collection/ArtifactTransformer.py
+++ b/source/transformer/app/transformers/museum/collection/ArtifactTransformer.py
@@ -243,7 +243,7 @@ class ArtifactTransformer(BaseTransformer):
 								identifier.classified_as = Type(ident="http://vocab.getty.edu/aat/300404626", label="Identification Number")
 								
 								# Map the "Getty Manuscript Number" classification
-								identifier.classified_as = Type(ident="http://vocab.getty.edu/internal/ontologies/linked-data/tms/object/number/manuscript", label="Getty Manuscript Number")
+								identifier.classified_as = Type(ident="https://data.getty.edu/museum/ontology/linked-data/tms/object/number/manuscript", label="Getty Manuscript Number")
 								
 								entity.identified_by = identifier
 	
@@ -300,11 +300,11 @@ class ArtifactTransformer(BaseTransformer):
 								
 								# Classify the title using the subtype provided by TMS; in the future hopefully we can add or replace these
 								# home-grown classifications with something official from AAT or another controlled vocabulary...
-								name.classified_as = Type(ident="http://vocab.getty.edu/internal/ontologies/linked-data/tms/object/titles/" + hyphenatedStringFromSpacedString(subtype.lower()), label=subtype.title())
+								name.classified_as = Type(ident="https://data.getty.edu/museum/ontology/linked-data/tms/object/titles/" + hyphenatedStringFromSpacedString(subtype.lower()), label=subtype.title())
 								
 								remarks = get(title, "remarks")
 								if(remarks):
-									name.classified_as = Type(ident="http://vocab.getty.edu/internal/ontologies/linked-data/tms/object/titles/" + hyphenatedStringFromSpacedString(remarks.lower()), label=remarks.title())
+									name.classified_as = Type(ident="https://data.getty.edu/museum/ontology/linked-data/tms/object/titles/" + hyphenatedStringFromSpacedString(remarks.lower()), label=remarks.title())
 								
 								related = get(title, "related")
 								if(related):

--- a/source/transformer/app/transformers/museum/collection/BaseTransformer.py
+++ b/source/transformer/app/transformers/museum/collection/BaseTransformer.py
@@ -222,9 +222,9 @@ class BaseTransformer(SharedMuseumBaseTransformer):
 			identifier._label = "Getty Digital Object Repository (DOR) ID"
 			identifier.content = number
 			
-			identifier.classified_as = Type(ident="http://vocab.getty.edu/internal/ontologies/linked-data/dor-identifier", label="Getty Digital Object Repository (DOR) ID")
+			identifier.classified_as = Type(ident="https://data.getty.edu/museum/ontology/linked-data/dor/identifier", label="Getty Digital Object Repository (DOR) ID")
 			
-			identifier.classified_as = Type(ident="http://vocab.getty.edu/internal/ontologies/linked-data/integer-identifier", label="Integer Identifier")
+			identifier.classified_as = Type(ident="https://data.getty.edu/museum/ontology/linked-data/integer-identifier", label="Integer Identifier")
 			
 			entity.identified_by = identifier
 		
@@ -235,9 +235,9 @@ class BaseTransformer(SharedMuseumBaseTransformer):
 			identifier._label = "Getty Digital Object Repository (DOR) UUID"
 			identifier.content = number
 			
-			identifier.classified_as = Type(ident="http://vocab.getty.edu/internal/ontologies/linked-data/dor-identifier", label="Getty Digital Object Repository (DOR) ID")
+			identifier.classified_as = Type(ident="https://data.getty.edu/museum/ontology/linked-data/dor/identifier", label="Getty Digital Object Repository (DOR) ID")
 			
-			identifier.classified_as = Type(ident="http://vocab.getty.edu/internal/ontologies/linked-data/universally-unique-identifier", label="Universally Unique Identifier (UUID)")
+			identifier.classified_as = Type(ident="https://data.getty.edu/museum/ontology/linked-data/universally-unique-identifier", label="Universally Unique Identifier (UUID)")
 			
 			entity.identified_by = identifier
 	
@@ -252,8 +252,8 @@ class BaseTransformer(SharedMuseumBaseTransformer):
 			identifier._label = "Gallery Systems' The Museum System (TMS) ID"
 			identifier.content = number
 			
-			identifier.classified_as = Type(ident="http://vocab.getty.edu/internal/ontologies/linked-data/tms-identifier", label="Gallery Systems' The Museum System (TMS) ID")
+			identifier.classified_as = Type(ident="https://data.getty.edu/museum/ontology/linked-data/tms/identifier", label="Gallery Systems' The Museum System (TMS) ID")
 			
-			identifier.classified_as = Type(ident="http://vocab.getty.edu/internal/ontologies/linked-data/integer-identifier", label="Integer Identifier")
+			identifier.classified_as = Type(ident="https://data.getty.edu/museum/ontology/linked-data/integer-identifier", label="Integer Identifier")
 			
 			entity.identified_by = identifier


### PR DESCRIPTION
Modified the custom ontology term base URLs from their initial `http://vocab.getty.edu/internal/ontologies/linked-data/` pattern to the new `https://data.getty.edu/museum/ontology/linked-data/` pattern.