### PR TITLE
Remove Source Credit Line Primary Source Classification – DEV-2632

### DIFF
--- a/source/transformer/app/transformers/museum/collection/ArtifactTransformer.py
+++ b/source/transformer/app/transformers/museum/collection/ArtifactTransformer.py
@@ -122,8 +122,7 @@ class ArtifactTransformer(BaseTransformer):
 							# Map the "Artifacts (Object Genre)" classification to denote this as the Object Credit Line
 							lobj.classified_as = Type(ident="http://vocab.getty.edu/aat/300117127", label="Artifacts (Object Genre)")
 						elif(get(creditline, "subtype") == "SOURCE CREDIT LINE"):
-							# Map the "Primary Sources" classification to denote this as the Source Credit Line
-							lobj.classified_as = Type(ident="http://vocab.getty.edu/aat/300311936", label="Primary Sources")
+							pass
 						elif(get(creditline, "subtype") == "REPRODUCTION CREDIT LINE"):
 							# Map the "Reproductions (Derivative Items)" classification to denote this as the Reproduction Credit Line
 							lobj.classified_as = Type(ident="http://vocab.getty.edu/aat/300015643", label="Reproductions (Derivative Items)")


### PR DESCRIPTION
Remove _Primary Sources_ (300311936) AAT term classification from Source Credit Line.