### PR TITLE
Rename Environment Variables – DEV-2921

### DIFF
--- a/source/web-service/startup.sh
+++ b/source/web-service/startup.sh
@@ -7,12 +7,12 @@ echo "startup.sh path: ${DIR}";
 
 # run the process via uWSGI...
 uwsgi \
-	--http "0.0.0.0:${MART_WEB_SERVICE_PORT}" \
+	--http "0.0.0.0:${WEB_SERVICE_PORT}" \
 	--manage-script-name \
 	--wsgi-file="${DIR}/startup.py" \
 	--callable "app" \
 	--master \
-	--processes=${MART_UWSGI_PROCESSES} \
-	--threads=${MART_UWSGI_THREADS} \
+	--processes=${UWSGI_PROCESSES} \
+	--threads=${UWSGI_THREADS} \
 	--thunder-lock \
 	$@


### PR DESCRIPTION
Rename environment variables in Web Service `startup.sh` script, removing references to the deprecated `MART` prefix.