### PR TITLE
Additional Activity Stream Exception Handling – DEV-2946

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,11 +22,15 @@ DOR_API_KEY=<REDACTED>
 # Specify the DOR API Version and Cache Configuration
 DOR_API_VERSION=1.5
 DOR_API_CACHING=YES
+DOR_API_MAX_RETRIES=5
 
 # Specify the Base URL for our generated LOD records
 # This URL is the endpoint that our Web Service will be available from
 LOD_BASE_URL=https://data.getty.edu/museum/collection
 DOR_FIND_URL=
+
+# Activity Stream Defaults
+ACTIVITY_STREAM_MAX_RETRIES=3
 
 # Specify PostgreSQL Configuration
 POSTGRES_USER=mart

--- a/source/transformer/app/transformers/museum/collection/BaseTransformer.py
+++ b/source/transformer/app/transformers/museum/collection/BaseTransformer.py
@@ -54,6 +54,10 @@ class BaseTransformer(SharedMuseumBaseTransformer):
 		if(isNumeric(interval)):
 			options["interval"] = int(interval)
 		
+		retries = os.getenv("DOR_API_MAX_RETRIES", 5)
+		if(isNumeric(retries)):
+			options["retries"] = int(retries)
+		
 		# Define the HTTP request headers needed to access our Activity Stream
 		headers = self.assembleHeaders()
 		if(headers):


### PR DESCRIPTION
Added additional handling for Activity Stream exceptions to retry the request to obtain an Activity Stream page up to the defined maximum number of times to help work around temporary network or resource outages.