### PR TITLE
Use .env File for Environment Variable Configuration – DEV-2545

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,10 @@
 # Specify the required environment variables for our process
 
+# NOTE: DO NOT QUOTE VAULES IN THIS FILE; THE QUOTE MARKS WILL BECOME PART OF THE VAULE
+
+# Specify the shared library path
+LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64
+
 # Specify the command line shell to use (default to BASH rather than the simpler SH)
 SHELL=/bin/bash
 
@@ -7,48 +12,60 @@ SHELL=/bin/bash
 # Levels below 0 indicate that only errors should be emitted
 # Levels above 0 indicate the verbosity level for messages (errors will always be emitted)
 # Verbosity levels range from 1-3 from the lowest to the highest verbosity level
-DEBUG_LEVEL=-1
+DEBUG_LEVEL=0
 
 # Specify the time zone for our application
-TIMEZONE=America/Los_Angeles
+TZ=America/Los_Angeles
 
-# Specify the DOR API Base URL
-DOR_BASE_URL=https://atlas7.getty.edu
-
-# Specify the DOR API Credentials
-DOR_API_USER=<REDACTED>
-DOR_API_KEY=<REDACTED>
-
-# Specify the DOR API Version and Cache Configuration
-DOR_API_VERSION=1.5
-DOR_API_CACHING=YES
-DOR_API_MAX_RETRIES=5
-
-# Specify the Base URL for our generated LOD records
-# This URL is the endpoint that our Web Service will be available from
-LOD_BASE_URL=https://data.getty.edu/museum/collection
-DOR_FIND_URL=
-
-# Activity Stream Defaults
-ACTIVITY_STREAM_MAX_RETRIES=3
+# Specify the LOD base URL for our generated records
+# This must also be the base URL for MART's Web Service
+LOD_BASE_URL=https://mart.getty.edu
+# Should the LOD URLs be terminated with a forward slash?
+LOD_SLASH_URL=NO
 
 # Specify PostgreSQL Configuration
-POSTGRES_USER=mart
+POSTGRES_HOST=postgres
+POSTGRES_PORT=5432
+POSTGRES_USER=<REDACTED>
 POSTGRES_PASSWORD=<REDACTED>
-POSTGRES_DB=mart
-POSTGRES_PORT=6432
-POSTGRES_PGDATA=/var/lib/postgresql/data/mart
+POSTGRES_DB=<REDACTED>
+PGDATA=/var/lib/postgresql/data
+
+# Specify Neptune Configuration
+NEPTUNE_HOST=dev-1-neptune.aws.getty.edu
+NEPTUNE_PORT=8182
+NEPTUNE_ENABLED=NO
 
 # Specify Transformer Configuration
 TRANSFORMER_PORT=5200
-TRANSFORMER_URLS_TRAILING_SLASH=NO
 
 # Specify Web Service Configuration
+WEB_DEBUG_HEADER=NO
 WEB_SERVICE_PORT=5100
 FLASK_APP=/startup.py
 FLASK_DEBUG=0
 FLASK_ENV=production
+UWSGI_PROCESSES=4
+UWSGI_THREADS=2
+
+# Specify the DOR API Base URL, Credentials, Versioning and Cache Config
+DOR_BASE_URL=https://data.getty.edu/museum
+DOR_FIND_URL=
+DOR_POLL_INTERVAL=60
+DOR_API_USER=<REDACTED>
+DOR_API_KEY=<REDACTED>
+DOR_API_VERSION=1.5
+DOR_API_CACHING=YES
+DOR_API_MAX_RETRIES=5
 
 # LOD UUIDv5 Name Spaces
 LOD_UUID_NAMESPACE_PLACES=3ab4a96d-cfd5-4f47-8d16-812be76c1215
 
+# Activity Stream Defaults
+ACTIVITY_STREAM_MAX_RETRIES=3
+
+# Specify the Vault Configuration
+VAULT_ADDR=<REDACTED>
+VAULT_ENV=<REDACTED>
+VAULT_APP_NAME=<REDACTED>
+VAULT_TOKEN=<REDACTED>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,14 +5,8 @@ services:
         build:
             context: ./
             dockerfile: ./services/postgres/Dockerfile
-        environment:
-            POSTGRES_HOST:     ${POSTGRES_HOST}
-            POSTGRES_USER:     ${POSTGRES_USER}
-            POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-            POSTGRES_DB:       ${POSTGRES_DB}
-            POSTGRES_PORT:     ${POSTGRES_PORT}
-            PGDATA:            ${POSTGRES_PGDATA}
-            TZ:                ${TIMEZONE}
+        env_file:
+            .env
         ports:
             - "${POSTGRES_PORT}:5432"
         stop_grace_period: 10s
@@ -24,26 +18,8 @@ services:
         build:
             context: ./
             dockerfile: ./source/transformer/Dockerfile
-        environment:
-            LD_LIBRARY_PATH:   /usr/local/lib:/usr/local/lib64
-            SHELL:             ${SHELL}
-            TZ:                ${TIMEZONE}
-            POSTGRES_HOST:     ${POSTGRES_HOST}
-            POSTGRES_PORT:     ${POSTGRES_PORT}
-            POSTGRES_USER:     ${POSTGRES_USER}
-            POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-            POSTGRES_DB:       ${POSTGRES_DB}
-            NEPTUNE_HOST:      ${NEPTUNE_HOST}
-            NEPTUNE_PORT:      ${NEPTUNE_PORT}
-            NEPTUNE_ENDPOINT:  ${NEPTUNE_ENDPOINT}
-            DOR_BASE_URL:      ${DOR_BASE_URL}
-            DOR_FIND_URL:      ${DOR_FIND_URL}
-            DOR_API_USER:      ${DOR_API_USER}
-            DOR_API_KEY:       ${DOR_API_KEY}
-            DOR_API_VERSION:   ${DOR_API_VERSION}
-            DOR_API_CACHING:   ${DOR_API_CACHING}
-            LOD_BASE_URL:      ${LOD_BASE_URL}
-            LOD_SLASH_URL:     ${LOD_SLASH_URL}
+        env_file:
+            .env
         volumes:
             # use a volume mount to dynamically bind the application's source code
             - ./source/transformer/startup.py:/startup.py
@@ -75,25 +51,8 @@ services:
         build:
             context: ./
             dockerfile: ./source/web-service/Dockerfile
-        environment:
-            LD_LIBRARY_PATH:   /usr/local/lib:/usr/local/lib64
-            SHELL:             ${SHELL}
-            TZ:                ${TIMEZONE}
-            POSTGRES_HOST:     ${POSTGRES_HOST}
-            POSTGRES_PORT:     ${POSTGRES_PORT}
-            POSTGRES_USER:     ${POSTGRES_USER}
-            POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-            POSTGRES_DB:       ${POSTGRES_DB}
-            NEPTUNE_HOST:      ${NEPTUNE_HOST}
-            NEPTUNE_PORT:      ${NEPTUNE_PORT}
-            LOD_BASE_URL:      ${LOD_BASE_URL}
-            FLASK_ENV:         ${FLASK_ENV}
-            FLASK_DEBUG:       ${FLASK_DEBUG}
-            FLASK_APP:         ${FLASK_APP}
-            WEB_SERVICE_PORT:  ${WEB_SERVICE_PORT}
-            WEB_DEBUG_HEADER:  ${WEB_DEBUG_HEADER}
-            UWSGI_PROCESSES:   ${UWSGI_PROCESSES}
-            UWSGI_THREADS:     ${UWSGI_THREADS}
+        env_file:
+            .env
         volumes:
             # use a volume mount to dynamically bind the application's source code
             - ./source/web-service/startup.py:/startup.py


### PR DESCRIPTION
Updated the project’s `docker-compose.yml` to use the `env_file` directive to bring in default environment configuration values from the project’s `.env` file. This simplifies environment variable configuration and utilization.