### PR TITLE
Map Object Place Created LinguisticObject – DEV-2979

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Any notable changes to the LOD Gateway that affect either functionality or output will be documented in this file (the format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)).
 
+## [Unreleased] 2019-11-13
+
+### Changed
+
+* Changed the mapping of an Object's "Place Created" property. This was formerly provided as a reference to an incomplete `Place` entity via the the `produced_by` property's `took_place_at` clause. However, as we do not currently have reconciled Place Created data, the verbatim Place Created display string is now more correctly provided via the `content` value of a `LinguisticObject` within the `produced_by` property's `referred_to_by` clause. This new Place Created `LinguisticObject` is classified with the AAT "Place Names" (300404655) and "Brief Text" (300418049) terms, as well as a custom "Place Created" classification. In the future when we have access to reconciled Place Created metadata that would allow linking to [The Getty Thesaurus of Geographic Names ® (TGN)](http://www.getty.edu/research/tools/vocabularies/tgn/about.html), we will do so via the `took_place_at` property, in addition to continuing to provide access to the Place Created display string via the newly added `LinguisticObject` [[DEV-2979](https://jira.getty.edu/browse/DEV-2979)].
+
 ## [Unreleased] 2019-10-14
 
 ### Changed

--- a/source/transformer/app/transformers/museum/collection/ArtifactTransformer.py
+++ b/source/transformer/app/transformers/museum/collection/ArtifactTransformer.py
@@ -1124,39 +1124,19 @@ class ArtifactTransformer(BaseTransformer):
                     # involved, one (or maybe more) for each maker, for different timespans of creation of the work?
 
                     # Object Place Created
-                    # Add via the "took_place_at" property of the Production activity
+                    # Add via a LinguisticObject on the referred_to_by property of the Production activity
                     if created:
                         placeName = get(created, "display.value")
-                        if placeName:
-                            placeUUID = str(
-                                uuid.uuid5(
-                                    uuid.UUID(os.getenv("LOD_UUID_NAMESPACE_PLACES")),
-                                    placeName,
-                                )
-                            )
+                        if isinstance(placeName, str) and len(placeName) > 0:
+                            lobj = LinguisticObject()
+                            lobj.id = self.generateEntityURI(sub=["place", "created"])
+                            lobj._label = "Place Created"
+                            lobj.content = placeName
+                            lobj.classified_as = Type(ident="http://vocab.getty.edu/aat/300404655", label="Place Names")
+                            lobj.classified_as = Type(ident="http://vocab.getty.edu/aat/300418049", label="Brief Text")
+                            lobj.classified_as = Type(ident="https://data.getty.edu/museum/ontology/linked-data/tms/object/place/created", label="Place Created")
 
-                            place = Place()
-
-                            place._namespace = self.getNamespace()
-                            place._uuid = placeUUID
-                            place._label = placeName
-
-                            place.id = self.generateEntityURI(
-                                entity=Place, UUID=placeUUID
-                            )
-
-                            # Map the place name
-                            name = Name()
-                            name.id = self.generateEntityURI(
-                                entity=Place, UUID=placeUUID, sub=["name"]
-                            )
-                            name.content = placeName
-
-                            # Map the place name
-                            place.identified_by = name
-
-                            if manager.storeEntity(place):
-                                production.took_place_at = place
+                            production.referred_to_by = lobj
 
                     entity.produced_by = production
 


### PR DESCRIPTION
Added an improved mapping for an Object’s Place Created display string, provided via the `content` property of a new `LinguisticObject` mapped into the Object record’s `produced_by` property’s `referred_to_by` clause. This replaces the former link to an incomplete `Place` entity which was associated via the Object record’s `produced_by` property’s `took_place_at` clause. We will reuse the `took_place`at` clause in the future when we have access to reconciled Place Created metadata that links to TGN.

Updated the project’s `CHANGELOG.md` to reflect this change.