### PR TITLE
Map Object Place Created LinguisticObject – DEV-2979

### DIFF
--- a/source/transformer/app/transformers/museum/collection/ArtifactTransformer.py
+++ b/source/transformer/app/transformers/museum/collection/ArtifactTransformer.py
@@ -721,10 +721,6 @@ class ArtifactTransformer(BaseTransformer):
 
                         entity.carries = lobj
 
-    # Map Object Place Created
-    def mapPlaceCreated(self, entity, data):
-        pass
-
     # Map Object Place Depicted
     def mapPlaceDepicted(self, entity, data):
         depicted = get(data, "display.places.depicted.display.value")


### PR DESCRIPTION
Removed the `ArtifactTransformer` class’ unused `mapPlaceCreated()` method as the Place Created mapping needs to occur within the class’ `mapArtistMakerRelationships()` method due to the need for attaching the Place Created `LiguisticObject` to the `produced_by` property’s `referred_to_by` clause, which doesn’t exist until the Artist/Maker relationship mapping is already underway in the latter method.