### PR TITLE
Map Object Place Depicted LinguisticObject – DEV-2981

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Any notable changes to the LOD Gateway that affect either functionality or outpu
 
 + Added a mapping for an Object's Place Found verbatim display string. This has been provided, where available, via the `content` property of a new `LinguisticObject`, which has been added to an Object record's top-level `referred_to_by` property. The Place Found `LinguisticObject` has been classified with the AAT "Place Names" (300404655) and "Brief Text" (300418049) terms, as well as a custom "Place Found" classification, to allow it to be distinguished from other Place display strings and other `LinguisticObject` instances [[DEV-2980](https://jira.getty.edu/browse/DEV-2980)].
 
++ Added a mapping for an Object's Place Depicted verbatim display string. This has been provided, where available, via the `content` property of a new `LinguisticObject`, which has been added to an Object record's top-level `shows` property, via its `VisualItem`. The Place Depicted `LinguisticObject` is associated with the `VisualItem` via its `referred_to_by` property, and has been classified with the AAT "Place Names" (300404655) and "Brief Text" (300418049) terms, as well as a custom "Place Depicted" classification, to allow it to be distinguished from other Place display strings and other `LinguisticObject` instances [[DEV-2981](https://jira.getty.edu/browse/DEV-2981)].
+
 ## [Unreleased] 2019-10-14
 
 ### Changed

--- a/source/transformer/app/transformers/museum/collection/ArtifactTransformer.py
+++ b/source/transformer/app/transformers/museum/collection/ArtifactTransformer.py
@@ -725,24 +725,21 @@ class ArtifactTransformer(BaseTransformer):
     def mapPlaceDepicted(self, entity, data):
         depicted = get(data, "display.places.depicted.display.value")
         if depicted:
-            id = get(data, "display.places.depicted.uuid")
-            if id:
-                visual = VisualItem()
-                visual.id = self.generateEntityURI(sub=["shows", id])
+            visual = VisualItem()
+            visual.id = self.generateEntityURI(sub=["shows"])
 
-                place = Place()
-                place.id = self.generateEntityURI(sub=["place", id])
-                place._label = depicted
+            lobj = LinguisticObject()
+            lobj.id = self.generateEntityURI(sub=["shows", "place", "depicted"])
+            lobj._label = "Place Depicted"
+            lobj.content = depicted
 
-                name = Name()
-                name.id = self.generateEntityURI(sub=["place", "name", id])
-                name.content = depicted
+            lobj.classified_as = Type(ident="http://vocab.getty.edu/aat/300404655", label="Place Names")
+            lobj.classified_as = Type(ident="http://vocab.getty.edu/aat/300418049", label="Brief Text")
+            lobj.classified_as = Type(ident="https://data.getty.edu/museum/ontology/linked-data/tms/object/place/depicted", label="Place Depicted")
 
-                place.identified_by = name
+            visual.referred_to_by = lobj
 
-                visual.represents = place
-
-                entity.shows = visual
+            entity.shows = visual
 
     # Map Object Place Found
     def mapPlaceFound(self, entity, data):


### PR DESCRIPTION
Added a mapping for an Object's Place Depicted verbatim display string. This has been provided, where available, via the `content` property of a new `LinguisticObject`, which has been added to an Object record's top-level `shows` property, via its `VisualItem`.

The Place Depicted `LinguisticObject` is associated with the `VisualItem` via its `referred_to_by` property, and has been classified with the AAT "Place Names" (300404655) and "Brief Text" (300418049) terms, as well as a custom "Place Depicted" classification, to allow it to be distinguished from other Place display strings and other `LinguisticObject` instances.

Updated the project’s `CHANGELOG.md` file to reflect the addition.