### PR TITLE
Rename Model Class' Count Method – DEV-2993

### DIFF
--- a/source/app/model/__init__.py
+++ b/source/app/model/__init__.py
@@ -311,9 +311,9 @@ class Model(ABC):
                 }
 
     @classmethod
-    def count(cls, *args, **kwargs):
+    def recordCount(cls, *args, **kwargs):
         debug(
-            "%s.count(args: %s, kwargs: %s) called..." % (cls.__name__, args, kwargs),
+            "%s.recordCount(args: %s, kwargs: %s) called..." % (cls.__name__, args, kwargs),
             level=1,
         )
 

--- a/source/web-service/app/routes/activity.py
+++ b/source/web-service/app/routes/activity.py
@@ -106,7 +106,7 @@ def activityStream(path=None):
         query = {}
 
     start = 1
-    count = Activity.count(**query)
+    count = Activity.recordCount(**query)
     limit = request.args.get("limit", default=100, type=int)
     offset = request.args.get("offset", default=0, type=int)
     first = 0


### PR DESCRIPTION
Renamed Model class’ `count()` method to `recordCount()` to avoid potential confusion with standard library `count()` method.