### PR TITLE
Fix Unified Model Class' Parameter Parsing Method Signatures – DEV-3012

### DIFF
--- a/source/app/model/__init__.py
+++ b/source/app/model/__init__.py
@@ -311,7 +311,7 @@ class Model(ABC):
                 }
 
     @classmethod
-    def _parse_clause(*args, **kwargs):
+    def _parse_clause(cls, *args, **kwargs):
         clause = None
         if "clause" in kwargs:
             if isinstance(kwargs["clause"], str) and len(kwargs["clause"]) > 0:
@@ -327,7 +327,7 @@ class Model(ABC):
         return clause
 
     @classmethod
-    def _parse_params(*args, **kwargs):
+    def _parse_params(cls, *args, **kwargs):
         params = None
         if "bind" in kwargs:
             params = kwargs["bind"]


### PR DESCRIPTION
Fixed method signatures for the new parameter parsing helper methods, to add the missing initial `cls` positional parameter.