### PR TITLE
Fix Blank Classification Type – DEV-3014

### DIFF
--- a/source/transformer/app/transformers/museum/collection/ArtifactTransformer.py
+++ b/source/transformer/app/transformers/museum/collection/ArtifactTransformer.py
@@ -223,7 +223,7 @@ class ArtifactTransformer(BaseTransformer):
 
         # Set defined Object Classification if available
         classification = get(data, "display.classification")
-        if classification:
+        if classification and has(classification, "classification.id"):
             # debug(classification, format="JSON")
 
             entity.classified_as = Type(


### PR DESCRIPTION
Fix cases of blank classification `Type` instances in Object records' top-level `classified_as` property, by adding additional validation to ensure we have the data to build out each new dynamic classification `Type`.