### PR TITLE
Create tests for AS Item generation

### DIFF
--- a/source/web-service/tests/test_routes_activity.py
+++ b/source/web-service/tests/test_routes_activity.py
@@ -52,7 +52,7 @@ def sample_item():
 
 
 class TestGenerateActivityStreamItem:
-    def test_happy_path(self, activity, record, sample_item):
+    def test_typical_functionality(self, activity, record, sample_item):
 
         item = generateActivityStreamItem(activity, record=record)
         assert item == sample_item


### PR DESCRIPTION
These tests encapsulate the functionality of generateActivityStreamItem
in preparation for any refactoring.

I also learned that `(scope="module")` doesn't do what I thought it did: instead of restricting the scope of the fixture to this module, it means that the scope only runs once for all tests of the module...which isn't at all what we want!