### PR TITLE
Move Producer Description – DEV-3106

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Any notable changes to the LOD Gateway that affect either functionality or outpu
 
 * Changed the mapping of an Object's "Place Created" property. This is now available via the `content` property of a `LinguisticObject` mapped within the Object record's top-level `referred_to_by` property and is classified with the AAT "Creation Place Description" (300435448) and "Brief Text" (300418049) terms [[DEV-3104](https://jira.getty.edu/browse/DEV-3104)].
 
+## Added
+
++ Added a mapping for display strings for an Object's artist/makers; these have been added as a `LinguisticObject` within the Object's Production activity (for works with one maker) or activities (for works with multiple makers). These `LinguisticObject` entities are classified with a custom "Producer Description" and AAT "Brief Text" (300418049) terms [[DEV-3106](https://jira.getty.edu/browse/DEV-3106)].
+
 ## [Unreleased] 2019-11-15
 
 ## Changed

--- a/source/transformer/app/transformers/museum/collection/ArtifactTransformer.py
+++ b/source/transformer/app/transformers/museum/collection/ArtifactTransformer.py
@@ -731,7 +731,8 @@ class ArtifactTransformer(BaseTransformer):
             lobj.content = created
 
             lobj.classified_as = Type(
-                ident="http://vocab.getty.edu/aat/300435448", label="Creation Place Description"
+                ident="http://vocab.getty.edu/aat/300435448",
+                label="Creation Place Description",
             )
 
             lobj.classified_as = Type(
@@ -739,7 +740,6 @@ class ArtifactTransformer(BaseTransformer):
             )
 
             entity.referred_to_by = lobj
-
 
     # Map Object Place Depicted
     def mapPlaceDepicted(self, entity, data):
@@ -1083,95 +1083,34 @@ class ArtifactTransformer(BaseTransformer):
                         label="Production of Artwork",
                     )
 
+                    # Artist/Maker Display Name (including any specified prefix and/or suffix and culture and dates)
+                    name_display = get(maker, "display.value_combined")
+                    if name_display:
+                        lobj = LinguisticObject(
+                            ident=self.generateEntityURI(
+                                sub=["production", id, "producer-description"]
+                            ),
+                            label="Artist/Maker (Producer) Description",
+                        )
+
+                        lobj.content = name_display
+
+                        lobj.classified_as = Type(
+                            ident="https://data.getty.edu/museum/ontology/linked-data/tms/object/producer-description",
+                            label="Producer Description",
+                        )
+
+                        lobj.classified_as = Type(
+                            ident="http://vocab.getty.edu/aat/300418049",
+                            label="Brief Text",
+                        )
+
+                        production.referred_to_by = lobj
+
                     person = Person(
                         ident=self.generateEntityURI(entity=Person, UUID=id),
                         label=value,
                     )
-
-                    # (?) Artist/Maker Name Full - Mapped in the Person record
-                    name_full = get(maker, "display.value")
-                    if name_full:
-                        name = Name(
-                            ident=self.generateEntityURI(
-                                entity=Person, UUID=id, sub=["name"]
-                            ),
-                            label="Artist/Maker Full Name",
-                        )
-
-                        name.content = name_full
-
-                        name.classified_as = Type(
-                            ident="http://vocab.getty.edu/aat/300404688",
-                            label="Full Names (Personal Names)",
-                        )
-
-                        person.referred_to_by = name
-
-                    # (?) Artist/Maker Life Dates - Mapped in the Person record
-
-                    # (?) Artist/Maker Nationality - Mapped in the Person record
-
-                    # Artist/Maker Name Prefix
-                    name_prefix = get(maker, "display.value_prefix")
-                    if name_prefix:
-                        name = Name(
-                            ident=self.generateEntityURI(
-                                entity=Person, UUID=id, sub=["name", "prefix"]
-                            ),
-                            label="Artist/Maker Name Prefix",
-                        )
-
-                        name.content = name_prefix
-
-                        name.classified_as = Type(
-                            ident="http://vocab.getty.edu/aat/300404845",
-                            label="Prefixes (Name Additions)",
-                        )
-
-                        person.referred_to_by = name
-
-                    # Artist/Maker Name Suffix
-                    name_suffix = get(maker, "display.value_suffix")
-                    if name_suffix:
-                        name = Name(
-                            ident=self.generateEntityURI(
-                                entity=Person, UUID=id, sub=["name", "suffix"]
-                            ),
-                            label="Artist/Maker Name Suffix",
-                        )
-
-                        name.content = name_suffix
-
-                        name.classified_as = Type(
-                            ident="http://vocab.getty.edu/aat/300404662",
-                            label="Suffixes (Name Additions)",
-                        )
-
-                        person.referred_to_by = name
-
-                    # Artist/Maker Display Name (including any specified prefix and/or suffix and culture and dates)
-                    name_display = get(maker, "display.value_combined")
-                    if name_display:
-                        name = Name(
-                            ident=self.generateEntityURI(
-                                entity=Person, UUID=id, sub=["name", "display"]
-                            ),
-                            label="Artist/Maker Display Name",
-                        )
-
-                        name.content = name_display
-
-                        name.classified_as = Type(
-                            ident="http://vocab.getty.edu/aat/300404688",
-                            label="Full Names (Personal Names)",
-                        )
-
-                        name.classified_as = Type(
-                            ident="http://vocab.getty.edu/aat/300404670",
-                            label="Preferred Term",
-                        )
-
-                        person.referred_to_by = name
 
                     # Artist/Maker Artwork Production Role
                     role = get(maker, "role")


### PR DESCRIPTION
Moved the producer description (artist/maker display string) from with a `Production` activity’s `Person` `referred_to_by` property, up one level into the `Production` activity’s `referred_to_by` property itself.

This is more semantically correct as the producer description was assigned later to describe the production event, and is not something that the `Person` attributed to themselves, which was otherwise implied when this information was carried within the `Person` reference.