### PR TITLE
Ignore GettyGuide Paging Short Title in Object Mapping – DEV-3148

### DIFF
--- a/source/transformer/app/transformers/museum/collection/ArtifactTransformer.py
+++ b/source/transformer/app/transformers/museum/collection/ArtifactTransformer.py
@@ -412,6 +412,7 @@ class ArtifactTransformer(BaseTransformer):
                                 "GETTYGUIDE SEARCH TITLE",
                                 "GETTYGUIDE MIDDLE TITLE",
                                 "GETTYGUIDE SHORT TITLE",
+                                "GETTYGUIDE PAGING SHORT TITLE",
                             ]:
                                 name = Name()
                                 name.id = self.generateEntityURI(sub=["name", id])


### PR DESCRIPTION
Added the `GETTYGUIDE PAGING SHORT TITLE` mnemonic to the ignore list to skip over GettyGuide Paging Short Titles in the `ArtifactTransformer` class’ `mapAlternateTitles()` method.