### PR TITLE
Fix Activity Stream DateTime Formatting – DEV-3232

### DIFF
--- a/source/web-service/flaskapp/routes/activity.py
+++ b/source/web-service/flaskapp/routes/activity.py
@@ -3,7 +3,12 @@ import math
 from flask import Blueprint, current_app
 
 from flaskapp.models import Activity
-from flaskapp.utilities import error_response, generate_url, validate_namespace
+from flaskapp.utilities import (
+    error_response,
+    generate_url,
+    validate_namespace,
+    format_datetime,
+)
 from app.utilities import hyphenatedStringFromCamelCasedString
 
 
@@ -135,7 +140,7 @@ def _generate_item(namespace, activity):
     return {
         "id": generate_url(namespace=namespace, sub=[str(activity.uuid)]),
         "type": activity.event,
-        "created": activity.datetime_created.strftime("%Y-%m-%dT%H:%M:%S:%z"),
+        "created": format_datetime(activity.datetime_created),
         "object": _generate_object(activity.record),
     }
 

--- a/source/web-service/flaskapp/utilities.py
+++ b/source/web-service/flaskapp/utilities.py
@@ -1,6 +1,7 @@
 import os
 
 from flask import Response, current_app
+from datetime import datetime
 
 
 def error_response(error):
@@ -52,3 +53,13 @@ def generate_url(namespace=None, sub=[], base=False):
     parts = [base_url, namespace, as_prefix, "/".join(sub)]
     parts = [item for item in parts if item]
     return "/".join(parts)
+
+
+def format_datetime(dt):
+    if isinstance(dt, datetime):
+        formatted = dt.strftime("%Y-%m-%dT%H:%M:%S%z")
+        if isinstance(formatted, str) and len(formatted) > 0:
+            formatted = formatted[:-2] + ":" + formatted[-2:]
+            return formatted
+
+    return None

--- a/source/web-service/tests/test_routes_activity.py
+++ b/source/web-service/tests/test_routes_activity.py
@@ -6,6 +6,8 @@ import pytest
 
 from flaskapp.utilities import generate_url
 from flaskapp.models import Activity
+from flaskapp.utilities import format_datetime
+from datetime import datetime
 
 
 @pytest.fixture(scope="module")
@@ -147,6 +149,13 @@ class TestPageRoute:
         url = "/museum/collection/activity-stream/page/0"
         response = client.get(url)
         assert response.status_code == 404
+
+    def test_format_datetime(self):
+        dt = datetime.fromisoformat("2019-12-04T15:36:12-08:00")
+        assert format_datetime(dt) == "2019-12-04T15:36:12-08:00"
+        assert format_datetime(None) == None
+        assert format_datetime(123) == None
+        assert format_datetime("abc") == None
 
 
 class TestItemRoute:


### PR DESCRIPTION
Fixed Activity Stream date/time formatting to correct the formatting of timezone offsets as they are unfortunately handled incorrectly by the Python standard library, despite what the documentation says.

Introduced a utility method `format_datetime()` to correctly format dates as xsd:Date compliant dates including the timezone offset, and added a test suite method to test that the `format_datetime()` method works as expected against various input conditions.

This corrects an issue where dates were being formatted with incorrect xsd:Date timezone formatting, such as `2019-11-22T13:02:53:-0800`, and corrects this using the new utility method, to format the dates correctly, like so: `2019-11-22T13:02:53-08:00`.