### PR TITLE
Modify activity query to remove offset and limit

### DIFF
--- a/source/web-service/flaskapp/routes/activity.py
+++ b/source/web-service/flaskapp/routes/activity.py
@@ -1,6 +1,7 @@
 import math
 
 from flask import Blueprint, current_app
+from sqlalchemy.orm import joinedload
 
 from flaskapp.models import Activity
 from flaskapp.utilities import (
@@ -97,7 +98,11 @@ def activity_stream_collection_page(namespace, pagenum):
             "type": "OrderedCollectionPage",
         }
 
-    activities = Activity.query.order_by("id").limit(limit).offset(offset)
+    activities = (
+        Activity.query.options(joinedload(Activity.record, innerjoin=True))
+        .filter(Activity.id > offset, Activity.id <= offset + limit)
+        .order_by("id")
+    )
     items = [_generate_item(namespace, a) for a in activities]
     data["orderedItems"] = items
 

--- a/source/web-service/tests/test_routes_activity.py
+++ b/source/web-service/tests/test_routes_activity.py
@@ -135,6 +135,25 @@ class TestPageRoute:
         payload = json.loads(response.data)
         assert "prev" not in payload.keys()
 
+    def test_item_ordering(self, client, current_app, sample_activity):
+        current_app.config["ITEMS_PER_PAGE"] = 2
+        a1 = sample_activity(1)
+        a2 = sample_activity(2)
+        a3 = sample_activity(3)
+        response = json.loads(client.get("/ns/activity-stream/page/1").data)
+        response2 = json.loads(client.get("/ns/activity-stream/page/2").data)
+
+        assert a1.record.id == 1
+        assert a2.record.id == 2
+        assert a3.record.id == 3
+
+        assert len(response["orderedItems"]) == 2
+        assert len(response2["orderedItems"]) == 1
+
+        assert a1.record.uuid in response["orderedItems"][0]["object"]["id"]
+        assert a2.record.uuid in response["orderedItems"][1]["object"]["id"]
+        assert a3.record.uuid in response2["orderedItems"][0]["object"]["id"]
+
     def test_out_of_bounds_page(self, client, sample_data):
         url = "/museum/collection/activity-stream/page/99999"
         response = client.get(url)


### PR DESCRIPTION
This should improve performance of the query for deep pages.