### PR TITLE
Handle missing ids appropriately in pagination.

### DIFF
--- a/source/web-service/flaskapp/routes/activity.py
+++ b/source/web-service/flaskapp/routes/activity.py
@@ -71,14 +71,12 @@ def activity_stream_collection_page(namespace, pagenum):
 
     limit = current_app.config["ITEMS_PER_PAGE"]
 
-    first = Activity.query.options(load_only("id")).order_by("id").first()
-    if first == None:
+    last = Activity.query.options(load_only("id")).order_by(desc("id")).first()
+    if last == None:
         return error_response((404, "No records in system"))
 
-    first_id = first.id
-    last_id = Activity.query.options(load_only("id")).order_by(desc("id")).first().id
-    offset = first_id - 1 + (pagenum - 1) * limit
-    total_pages = math.ceil(last_id / limit)
+    offset = (pagenum - 1) * limit
+    total_pages = math.ceil(last.id / limit)
 
     if pagenum == 0 or pagenum > total_pages:
         return error_response((404, "Page number out of bounds"))

--- a/source/web-service/tests/test_routes_activity.py
+++ b/source/web-service/tests/test_routes_activity.py
@@ -168,12 +168,12 @@ class TestPageRoute:
         response = json.loads(client.get("/ns/activity-stream/page/1").data)
         response2 = json.loads(client.get("/ns/activity-stream/page/2").data)
 
-        assert len(response["orderedItems"]) == 2
-        assert len(response2["orderedItems"]) == 1
+        assert len(response["orderedItems"]) == 1
+        assert len(response2["orderedItems"]) == 2
 
         assert a1.record.uuid in response["orderedItems"][0]["object"]["id"]
-        assert a2.record.uuid in response["orderedItems"][1]["object"]["id"]
-        assert a3.record.uuid in response2["orderedItems"][0]["object"]["id"]
+        assert a2.record.uuid in response2["orderedItems"][0]["object"]["id"]
+        assert a3.record.uuid in response2["orderedItems"][1]["object"]["id"]
 
     def test_id_missing(self, client, current_app, sample_activity, test_db):
         current_app.config["ITEMS_PER_PAGE"] = 2
@@ -223,6 +223,33 @@ class TestPageRoute:
 
         assert a1.record.uuid in response["orderedItems"][0]["object"]["id"]
         assert a2.record.uuid in response["orderedItems"][1]["object"]["id"]
+        assert a5.record.uuid in response3["orderedItems"][0]["object"]["id"]
+
+    def test_all_first_page_ids_missing(
+        self, client, current_app, sample_activity, test_db
+    ):
+        current_app.config["ITEMS_PER_PAGE"] = 2
+
+        a1 = sample_activity(1)
+        a2 = sample_activity(2)
+        a3 = sample_activity(3)
+        a4 = sample_activity(4)
+        a5 = sample_activity(5)
+
+        test_db.session.delete(a1)
+        test_db.session.delete(a2)
+        test_db.session.commit()
+
+        response = json.loads(client.get("/ns/activity-stream/page/1").data)
+        response2 = json.loads(client.get("/ns/activity-stream/page/2").data)
+        response3 = json.loads(client.get("/ns/activity-stream/page/3").data)
+
+        assert len(response["orderedItems"]) == 0
+        assert len(response2["orderedItems"]) == 2
+        assert len(response3["orderedItems"]) == 1
+
+        assert a3.record.uuid in response2["orderedItems"][0]["object"]["id"]
+        assert a4.record.uuid in response2["orderedItems"][1]["object"]["id"]
         assert a5.record.uuid in response3["orderedItems"][0]["object"]["id"]
 
     def test_out_of_bounds_page(self, client, sample_data):


### PR DESCRIPTION
Turns out if you're missing IDs, it screws up count-based pagination.  Now handling min/max records.
