### PR TITLE
Add Format Property to Person Biography LinguisticObject – DEV-3370

### DIFF
--- a/source/transformer/app/transformers/museum/collection/ConstituentTransformer.py
+++ b/source/transformer/app/transformers/museum/collection/ConstituentTransformer.py
@@ -231,4 +231,6 @@ class ConstituentTransformer(BaseTransformer):
                 label="Biography Statement",
             )
 
+            lobj.format = "text/html"
+
             entity.referred_to_by = lobj


### PR DESCRIPTION
Added a `format` property to Person Biography `LinguisticObject` with a MIME type value of `text/html` corresponding with the current embedded HTML formatting of Person Biographies.