### PR TITLE
Add Custom Classification Term to RightsStatements.org Assertion – DEV-3387

### DIFF
--- a/source/transformer/app/transformers/museum/collection/ArtifactTransformer.py
+++ b/source/transformer/app/transformers/museum/collection/ArtifactTransformer.py
@@ -125,10 +125,16 @@ class ArtifactTransformer(BaseTransformer):
                 lobj._label = "RightsStatements.org Rights Assertion"
                 lobj.content = assertion
 
-                # Map the "Rights Statement" classification
+                # Map the custom "Rights Statement" classification
                 lobj.classified_as = Type(
-                    ident="http://vocab.getty.edu/aat/300055547",
+                    ident="https://data.getty.edu/museum/ontology/linked-data/object/rights-statement",
                     label="Rights Statement",
+                )
+
+                # Map the "Rights (Legal Concept)" classification
+                lobj.classified_as = Type(
+                    ident="http://vocab.getty.edu/aat/300417696",
+                    label="Rights (Legal Concept)",
                 )
 
                 # Map the "Brief Text" classification


### PR DESCRIPTION
Added a custom classification for the RightsStatements.org Assertion to replace the broader and mislabelled http://vocab.getty.edu/aat/300055547 (Legal Concepts) as taken from the Linked.art documentation. Additionally added the more appropriate http://vocab.getty.edu/aat/300417696 (Rights (Legal Concept)) term for additional clarification.