### PR TITLE
Port 5001 for VS Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ LOD_DEFAULT_URL_NAMESPACE=  # This should be the 'vanity' portion of the URL
                             # for example, "museum/collection"
 ```
 
+Using VS Code, it is possible to develop inside the container with full debugging and intellisence capabilities. Port 5001 is opened for remote debugging of the Flask app. For details see: https://code.visualstudio.com/docs/remote/containers
+
 
 **Technical Architecture**
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ services:
             - ./source/app:/app/app
         ports:
             - "${FLASK_RUN_PORT}:5100"
+            - "5001:5001"  # VS Code debugger
 
 volumes:
     data_postgres:


### PR DESCRIPTION
Opened port 5001 in 'docker-compose.yml' for remote debugging of the Flask app. Modified 'Readme.md" to reflect changes