### PR TITLE
update env.example to correctly connect to db

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,7 @@ LOD_BASE_URL=http://localhost:5100
 LOD_DEFAULT_URL_NAMESPACE=
 LOD_AS_DESC=Getty Activity Stream (Example)
 
-DATABASE=postgresql://mart:mart@postgres/mart
+DATABASE=postgresql://postgres@postgres/postgres
 PGDATA=/var/lib/postgresql/data
 
 FLASK_APP=/app/flaskapp


### PR DESCRIPTION
When starting from scratch, the DB is initialized with the PG_USER as the DB name, but we removed that username, so if it's not explicitly set, we use the default `postgres` user.