### PR TITLE
Add Content-Type Header Charset Specifier – DEV-4225

### DIFF
--- a/source/web-service/flaskapp/__init__.py
+++ b/source/web-service/flaskapp/__init__.py
@@ -61,6 +61,9 @@ def create_app():
         @app.after_request
         def add_header(response):
             response.headers["Server"] = "LOD Gateway/0.2"
+
+            if response.headers["Content-Type"] == "application/json":
+                response.headers["Content-Type"] = "application/json;charset=UTF-8"
             return response
 
         return app


### PR DESCRIPTION
Added an explicit `Content-Type` HTTP header for any JSON responses generated by LOD Gateway, adding the missing `charset=UTF-8` specifier to the header to ensure that clients receiving responses from the Gateway are able to decode those responses correctly, rather than having to perform content/character set ‘sniffing’ and potentially getting it wrong.