### PR TITLE
Update buildspec.staging.archivesspace.web.yml

### DIFF
--- a/config/buildspec.staging.archivesspace.web.yml
+++ b/config/buildspec.staging.archivesspace.web.yml
@@ -13,7 +13,7 @@ phases:
       - aws --version
       - $(aws ecr get-login --region $AWS_DEFAULT_REGION --no-include-email)
       - docker login --username ${GETTY_DOCKER_USER} --password=${GETTY_DOCKER_PASSWORD}
-      - WEB_SERVICE_REPOSITORY_URI=936189880821.dkr.ecr.us-west-2.amazonaws.com/staging-lod-gateway-archivesspace-web-service
+      - WEB_SERVICE_REPOSITORY_URI=936189880821.dkr.ecr.us-west-2.amazonaws.com/staging-lod_gateway_archivesspace-uwsgi
       - COMMIT_HASH=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)
       - IMAGE_TAG=${COMMIT_HASH:=latest}
   build:
@@ -30,6 +30,6 @@ phases:
       - docker push $WEB_SERVICE_REPOSITORY_URI:latest
       - docker push $WEB_SERVICE_REPOSITORY_URI:$IMAGE_TAG
       - echo Writing image definitions file...
-      - printf '[{"name":"Staging-LodGatewayArchivesSpace-Web-Service","imageUri":"%s"}]' $WEB_SERVICE_REPOSITORY_URI:$IMAGE_TAG > imagedefinitions.json
+      - printf '[{"name":"staging-lod_gateway_archivesspace-uwsgi","imageUri":"%s"}]' $WEB_SERVICE_REPOSITORY_URI:$IMAGE_TAG > imagedefinitions.json
 artifacts:
     files: imagedefinitions.json


### PR DESCRIPTION
update the staging version of archivesspace to meet the new naming convention requirements for containers and integrate with auto-discovery for uwsgi.