### PR TITLE
Update PyLD version to 2.0.2 and use it to produce N-Triples data.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ pytest-watch==4.2.0
 pytest-cov==2.8.1
 pytest-mock==2.0.0
 rdflib==4.2.2
-pyld==1.0.5
+PyLD==2.0.2
 rdflib-jsonld==0.4.0
 requests==2.23.0
 requests_mock==1.7.0


### PR DESCRIPTION
Resolves DEV-5148.

This simplifies JSON-LD to N-Triples transcoding. The only issue I can see is if the input JSON-LD data contains multiple graphs. I *think* this would probably be semantically invalid for this system, but also not sure it's guarded against in the API. Either way, use of JSON-LD data containing multiple graphs would result in invalid syntax when constructing the `INSERT DATA` update string. If this is a concern, we can add some code to ensure the data in N-Triples (ignoring the graphs), or add code to guard against this data being handled in the first place.