### PR TITLE
Additional Graph Expansion Exception Error Logging – DEV-7630

### DIFF
--- a/source/web-service/flaskapp/routes/ingest.py
+++ b/source/web-service/flaskapp/routes/ingest.py
@@ -431,6 +431,8 @@ def graph_expand(data, proc=None):
             proc = jsonld.JsonLdProcessor()
         serialized_nt = proc.to_rdf(data, {"format": "application/n-quads"})
     except Exception as e:
+        id = data["id"] if isinstance(data, dict) and "id" in data else "???"
+        current_app.logger.error("Graph expansion error for %s: %s" % (id, str(e)))
         return False
 
     return serialized_nt


### PR DESCRIPTION
Added additional graph expansion exception error logging to capture any
exception messages generated as a result to calls to the
`graph_expand()` method within the `ingest.py` route handler. This
should help discern the root cause of any graph expansion errors
encountered when records are POSTed to LOD Gateway for storage.