### PR TITLE
Setting listener queue at startup

### DIFF
--- a/source/web-service/startup.sh
+++ b/source/web-service/startup.sh
@@ -11,4 +11,5 @@ uwsgi \
 	--processes ${UWSGI_PROCESSES} \
 	--threads ${UWSGI_THREADS} \
 	--thunder-lock \
+	--listen 128
 	$@


### PR DESCRIPTION
Raising the listener queue to 128 from the default of 100 to match linux kernel