### PR TITLE
Add Explicit Content-Type UTF-8 Charset Declaration – DEV-7774

### DIFF
--- a/source/web-service/flaskapp/routes/records.py
+++ b/source/web-service/flaskapp/routes/records.py
@@ -95,6 +95,7 @@ def entity_record(entity_id):
             )
 
         response = current_app.make_response(data)
+        response.headers["Content-Type"] = "application/json;charset=UTF-8"
         response.headers["Last-Modified"] = format_datetime(record.datetime_updated)
         response.headers["ETag"] = record.checksum
         if current_app.config["KEEP_LAST_VERSION"] is True:


### PR DESCRIPTION
Added an explicit `charset=UTF-8` declaration to the Gateway’s records’
endpoint HTTP response `Content-Type` header to help ensure that
clients correctly decode LOD Gateway JSON content as UTF-8, which
despite that the JSON Specification (RFC 7159) advises, does not always
occur as illustrated in the associated Jira ticket (DEV-7774).

This simple fix ensures that all clients decode the LOD Gateway’s JSON
serialized content correctly as UTF-8, and has no negative impacts on
clients that already correctly decode and interpret the content as
UTF-8.