### PR TITLE
Wrapping the checksum check for ingest in env var check.

### DIFF
--- a/source/web-service/flaskapp/routes/ingest.py
+++ b/source/web-service/flaskapp/routes/ingest.py
@@ -188,24 +188,25 @@ def process_record(input_rec):
 
     # Record exists
     else:
-        if db_rec.is_old_version is True:
-            # check to see if existing record is the same as uploaded:
-            current_app.logger.warning(
-                f"Entity ID {db_rec.entity_id} ({db_rec.entity_type}) is an old version."
-            )
-            if not is_delete_request:
-                # Delete is allowed but not updates
-                current_app.logger.error(
-                    f"Ignoring attempted update to Entity ID {db_rec.entity_id}."
+        if current_app.config["KEEP_LAST_VERSION"] is True:
+            if db_rec.is_old_version is True:
+                # check to see if existing record is the same as uploaded:
+                current_app.logger.warning(
+                    f"Entity ID {db_rec.entity_id} ({db_rec.entity_type}) is an old version."
+                )
+                if not is_delete_request:
+                    # Delete is allowed but not updates
+                    current_app.logger.error(
+                        f"Ignoring attempted update to Entity ID {db_rec.entity_id}."
+                    )
+                    return (None, id, None)
+
+            chksum = checksum_json(data)
+            if chksum == db_rec.checksum:
+                current_app.logger.info(
+                    f"Data uploaded for {id} is identical to the record already uploaded based on checksum. Ignoring."
                 )
                 return (None, id, None)
-
-        chksum = checksum_json(data)
-        if chksum == db_rec.checksum:
-            current_app.logger.info(
-                f"Data uploaded for {id} is identical to the record already uploaded based on checksum. Ignoring."
-            )
-            return (None, id, None)
 
         # get primary key of existing record
         prim_key = db_rec.id


### PR DESCRIPTION
Missed an addition toggle for the KEEP_LAST_VERSION configuration. It should be possible for the versioning check and previous version saving to be turned off with this env var.