### PR TITLE
Orb work dev 7883

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,9 @@ workflows:
           context: GETTY
           tag: *imageTag
           service: *deploymentName
+          #service1:
+          # ...
+          #service10:
           environment: stage
           requires:
             - pocBuild


### PR DESCRIPTION
@garciagregg I've added an `Orb` which is reusable logic to the top of the config (in a later step, we'll create a shared repo for this).  But, for now, trying to test that this logic works with your repo.  The goal here is to reduce the shared code between each project:

1. added the orb
2. removed common logic from the config
3. tried to apply the Orb

next step here is to uncomment the work to include the `orb_work_DEV-7883` branch so we can deploy into the Kubernetes world (but I wanted to run all of this by you first).