### PR TITLE
itsdangerous - pin to 2.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ PyLD==2.0.2
 rdflib-jsonld==0.4.0
 requests==2.23.0
 requests_mock==1.7.0
+itsdangerous==2.0.1


### PR DESCRIPTION
The latest version of itsdangerous is incompatible with this version of Flask. There should be a general update in versions used but in the meantime, pinning this package to 2.0.1 will fix this issue.