### PR TITLE
Tweaking the query to be more perfomant at the end of an activitystream

### DIFF
--- a/source/web-service/flaskapp/routes/activity.py
+++ b/source/web-service/flaskapp/routes/activity.py
@@ -106,7 +106,7 @@ def activity_stream_page(pagenum):
     # This should be faster than the original at high offset values
     # but will slightly increase query time in the first few pages.
     offset_id = db.session.execute(
-        f"select id from activities order by id offset {offset} limit 1;"
+        f"select id from activities order by id limit 1 offset {offset};"
     ).scalar()
     if offset_id is None:
         # Somehow managed to send through an offset that is too high


### PR DESCRIPTION
Using museum/collection as a test point, I can get the final page of the museum/collection feed in 2.7s over pulse secure. It should be a little quicker once deployed but I can't tell by how much.