### PR TITLE
Adding 'Cache-control: no-cache' to all responses

### DIFF
--- a/source/web-service/flaskapp/__init__.py
+++ b/source/web-service/flaskapp/__init__.py
@@ -195,6 +195,9 @@ def create_app():
                 "SERVER_CAPABILITIES"
             ]
 
+            # Cache-control
+            response.headers["Cache-Control"] = "no-cache"
+
             return response
 
         return app


### PR DESCRIPTION
Getting some task management data inconsistencies that are consistent with requests getting stale data when a resource has been very recently updated. Given that the requests are traversing the whole nginx/load-balancer stack out of the k8s cluster and back in, adding a header like this should help ensure that no proxy decides to serve stale data accidentally.