### PR TITLE
Turning off strict mode to debug in staging

### DIFF
--- a/source/web-service/uwsgi.ini
+++ b/source/web-service/uwsgi.ini
@@ -1,5 +1,5 @@
 [uwsgi]
-strict = true
+strict = false
 manage-script-name = true
 wsgi-file = ./wsgi.py
 callable = app


### PR DESCRIPTION
Some uwsgi.ini directives are being rejected in staging after a rebuild - turning off strict to debug to find out what has gone on