### PR TITLE
Yet another pyld workaround

### DIFF
--- a/source/web-service/flaskapp/routes/records.py
+++ b/source/web-service/flaskapp/routes/records.py
@@ -463,11 +463,11 @@ def entity_record(entity_id):
                         ident = data.get("id") or data.get("@id")
 
                         # rdflib to load and format the nquads
+                        # forcing it, because of pyld's awful nquad export
                         g = get_bound_graph(identifier=ident)
 
                         # May not be nquads, even though we requested it:
-                        if is_ntriples(serialized_rdf.split("\n")[0]):
-                            serialized_rdf = triples_to_quads(serialized_rdf, ident)
+                        serialized_rdf = triples_to_quads(serialized_rdf, ident)
 
                         g.parse(data=serialized_rdf, format="nquads")
                         data = g.serialize(format=desired[1])

--- a/source/web-service/flaskapp/utilities.py
+++ b/source/web-service/flaskapp/utilities.py
@@ -60,7 +60,11 @@ def quads_to_triples(quads):
 def triples_to_quads(ntriples, namedgraph):
     return "\n".join(
         [
-            f"{x.rsplit(' ', 1)[0]} <{namedgraph}> ."
+            (
+                lambda l: f"{l.rsplit(' ', 1)[0]} <{namedgraph}> ."
+                if NTRIPLES.match(l) is not None
+                else l
+            )(x)
             for x in ntriples.split("\n")
             if x.strip()
         ]


### PR DESCRIPTION
Seems that there are other cases, typically where the resource is made from fewer quads, where PyLD might output a mixture of ntriples and nquads when nquads are requested. This processes the output before parsing and re-serializing it and forces them all to be nquads. This stops unexpected errors being thrown in a small number of resources that seem to trigger this failure in pyld.