### PR TITLE
Version accept-datetime redirect fix

### DIFF
--- a/source/web-service/flaskapp/routes/records.py
+++ b/source/web-service/flaskapp/routes/records.py
@@ -359,6 +359,7 @@ def entity_record(entity_id):
                     url_for(
                         "records.entity_version",
                         entity_id=desired_version.entity_id,
+                        **request.args,
                     ),
                     code=302,
                 )


### PR DESCRIPTION
The version redirect should also include any get parameters sent to the service originally