### PR TITLE
Revert "Shifting to use a non-blocking library to make SPARQL proxy calls"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 psycopg2-binary==2.9.3
 SQLAlchemy==1.4.32
 alembic==1.11.1
-Flask[async]==2.3.2
+Flask==2.3.2
 Flask-Compress==1.11
 Flask-Cors==3.0.10
 Flask-Migrate==4.0.4
@@ -11,8 +11,6 @@ pytest==7.0.1
 pytest-cov==3.0.0
 pytest-mock==3.7.0
 pytest-watch==4.2.0
-pytest-asyncio==0.21.1
-pytest-httpx==0.22.0
 #PyLD==2.0.2
 git+https://github.com/thegetty/pyld.git@threadlocking#egg=pyld
 rdflib==6.3.2
@@ -23,4 +21,3 @@ regex==2022.3.2
 gunicorn==20.1.0
 python-json-logger==2.0.7
 gevent==22.10.2
-httpx==0.24.1


### PR DESCRIPTION
Reverts thegetty/lod-gateway#411

Had some conflicts with the gunicorn gevent - switching back to what it was before with the requests library and gunicorn's monkey patching. 