### PR TITLE
Updating the quads regex to handle bnodes in the RDFLib format

### DIFF
--- a/source/web-service/flaskapp/storage_utilities/graph.py
+++ b/source/web-service/flaskapp/storage_utilities/graph.py
@@ -151,7 +151,7 @@ def graph_expand(data, proc=None):
         )
         return serialized_nt
     else:
-        current_app.logger.info(f"{json_ld_id} - expanding using PyLD")
+        current_app.logger.info(f"{json_ld_id} - expanding using RDFLib")
         current_app.logger.debug(
             f"{json_ld_id} - RDFLIB parsing START at timecode {time.perf_counter() - tictoc}"
         )

--- a/source/web-service/flaskapp/utilities.py
+++ b/source/web-service/flaskapp/utilities.py
@@ -22,7 +22,7 @@ class Event(Enum):
 # Match quads only - doesn't handle escaped quotes yet, but the use of @graph JSON-LD will
 # be specific to things like repeated triples and not general use. The regex could be  smarter
 QUADS = re.compile(
-    r"^(\<[^\>]*\>\s){2}(\<[^\>]*\>|\"(?:[^\"\\]|\\.)*\")(\^\^\<[^\>]*\>){0,1}\s(\<[^\>]*\>|_\:[A-z0-9]*)\s\.$"
+    r"^(\<[^\>]*\>\s|_\:[A-z0-9]*\s){2}(_\:[A-z0-9]*|\<[^\>]*\>|\"(?:[^\"\\]|\\.)*\")(\^\^\<[^\>]*\>){0,1}\s(\<[^\>]*\>|_\:[A-z0-9]*)\s\.$"
 )
 NTRIPLES = re.compile(
     r"^(\<[^\>]*\>\s){2}(\<[^\>]*\>|\"(?:[^\"\\]|\\.)*\")(\^\^\<[^\>]*\>){0,1}\s\.$"


### PR DESCRIPTION
Needed to update the regex to match BNodes when present in nquad data.

RDFlib adheres closer to the spec around parsing graphs into a quadstore, and gives full nquads output with triples assigned to a bnode named graph. Pyld pushed things into the default graph and so nquads output was actually ntriples and bnodes in the data never tripped over this case.