### PR TITLE
Hotfix - prefix search

### DIFF
--- a/source/web-service/flaskapp/routes/records.py
+++ b/source/web-service/flaskapp/routes/records.py
@@ -91,6 +91,7 @@ def handle_prefix_listing(entity_id, request, idPrefix):
     records = (
         Record.query.options(
             load_only(
+                Record.id,
                 Record.entity_id,
                 Record.entity_type,
                 Record.datetime_updated,
@@ -99,6 +100,7 @@ def handle_prefix_listing(entity_id, request, idPrefix):
         )
         .filter(Record.datetime_deleted == None)
         .filter(Record.entity_id.like(entity_id[:-1] + "%"))
+        .order_by(Record.id)
     )
     # Pagination - GET URL parameter 'page'
     page = 1


### PR DESCRIPTION
I've started to see some queries to this return different paginations from deployed instances. A few possible reasons for this, but ultimately adding this order by term should force it to be deterministic, regardless of which pod/db cluster worker a request talks to.