### PR TITLE
Sort key setting

### DIFF
--- a/source/web-service/flaskapp/__init__.py
+++ b/source/web-service/flaskapp/__init__.py
@@ -96,12 +96,14 @@ def create_app():
     app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
 
     # For Flask <2.3 and retained for app config inspection:
-    app.config["JSON_SORT_KEYS"] = True
+    # Default for this application is to NOT sort:
+    app.config["JSON_SORT_KEYS"] = False
+    app.json.sort_keys = False
 
-    if "false" in environ.get("JSON_SORT_KEYS", "false"):
+    if "true" in environ.get("JSON_SORT_KEYS", "false").lower():
         # for Flask 2.3+
-        app.json.sort_keys = False
-        app.config["JSON_SORT_KEYS"] = False
+        app.config["JSON_SORT_KEYS"] = True
+        app.json.sort_keys = True
 
     app.config["ITEMS_PER_PAGE"] = 100
     app.config["AS_DESC"] = environ["LOD_AS_DESC"]

--- a/source/web-service/flaskapp/__init__.py
+++ b/source/web-service/flaskapp/__init__.py
@@ -94,7 +94,15 @@ def create_app():
 
     app.config["SQLALCHEMY_DATABASE_URI"] = environ["DATABASE"]
     app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
-    app.config["JSON_SORT_KEYS"] = False
+
+    # For Flask <2.3 and retained for app config inspection:
+    app.config["JSON_SORT_KEYS"] = True
+
+    if "false" in environ.get("JSON_SORT_KEYS", "false"):
+        # for Flask 2.3+
+        app.json.sort_keys = False
+        app.config["JSON_SORT_KEYS"] = False
+
     app.config["ITEMS_PER_PAGE"] = 100
     app.config["AS_DESC"] = environ["LOD_AS_DESC"]
 


### PR DESCRIPTION
In Flask 2.3+, a new way is used to turn off the JSON sorting, which this adapts to. The default is to turn key sorting off, unless the JSON_SORT_KEY environment variable is set to 'true'. The order of keys will be the internal ordering of the JSON after it is parsed from the DB JSONB column. It *should* be the same as the order of keys in the original JSON-encoded string using python 3.10+ but that is not entirely guaranteed.