### PR TITLE
Memento TimeMap - make application/link-format the default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,6 +69,8 @@ KEEP_LAST_VERSION=True
 KEEP_VERSIONS_AFTER_DELETION=False
 # Do users need to authenticate to see old versions?
 VERSIONING_AUTHENTICATION=True
+# Memento TimeMap format default: (application/json or application/link-format)
+MEMENTO_PREFERRED_FORMAT=application/link-format
 
 # JSON output options:
 JSON_SORT_KEYS=False
@@ -78,6 +80,7 @@ ITEMS_PER_PAGE=100
 
 # Sub-addressing resolving:
 SUBADDRESSING=True
+
 
 # Add prefix to relative IDs in resources
 # Can use GET param '?relativeid=true' to skip prefixing on request

--- a/source/web-service/flaskapp/__init__.py
+++ b/source/web-service/flaskapp/__init__.py
@@ -172,6 +172,16 @@ def create_app():
     if environ.get("KEEP_VERSIONS_AFTER_DELETION", "False").lower() == "true":
         app.config["KEEP_VERSIONS_AFTER_DELETION"] = True
 
+    # Set the preferred output format for Memento responses.
+    # can only be application/json or application/link-format
+    app.config["MEMENTO_PREFERRED_FORMAT"] = "application/link-format"
+
+    if environ.get("MEMENTO_PREFERRED_FORMAT") in [
+        "application/json",
+        "application/link-format",
+    ]:
+        app.config["MEMENTO_PREFERRED_FORMAT"] = environ.get("MEMENTO_PREFERRED_FORMAT")
+
     app.config["LINK_HEADER_PREV_VERSION"] = False
     if environ.get("LINK_HEADER_PREV_VERSION", "False").lower() == "true":
         app.config["LINK_HEADER_PREV_VERSION"] = True

--- a/source/web-service/flaskapp/routes/timegate.py
+++ b/source/web-service/flaskapp/routes/timegate.py
@@ -124,7 +124,7 @@ def get_timemap(entity_id):
     if requested_fmt == "application/json":
         return jsonify(timemap), 200
     else:
-        lf = ",\n".join([json_to_linkformat(x) for x in timemap])
+        lf = " , \n".join([json_to_linkformat(x) for x in timemap])
         response = current_app.make_response(lf)
         response.content_type = "application/link-format;charset=utf-8"
         response.mimetype = "application/link-format"

--- a/source/web-service/flaskapp/routes/timegate.py
+++ b/source/web-service/flaskapp/routes/timegate.py
@@ -117,7 +117,11 @@ def get_timemap(entity_id):
             timemap.append(mm)
 
     # Response format? config['MEMENTO_PREFERRED_FORMAT'] for the default
-    if requested_linkformat(request, mementoformat) == "application/json":
+    requested_fmt = requested_linkformat(request, mementoformat)
+    current_app.logger.info(
+        f"Accept: {request.headers.get('accept')}, pref: {mementoformat}, tm format decision: {requested_fmt}"
+    )
+    if requested_fmt == "application/json":
         return jsonify(timemap), 200
     else:
         lf = ",\n".join([json_to_linkformat(x) for x in timemap])

--- a/source/web-service/flaskapp/routes/timegate.py
+++ b/source/web-service/flaskapp/routes/timegate.py
@@ -118,7 +118,7 @@ def get_timemap(entity_id):
 
     # Response format? config['MEMENTO_PREFERRED_FORMAT'] for the default
     requested_fmt = requested_linkformat(request, mementoformat)
-    current_app.logger.info(
+    current_app.logger.debug(
         f"Accept: {request.headers.get('accept')}, pref: {mementoformat}, tm format decision: {requested_fmt}"
     )
     if requested_fmt == "application/json":

--- a/source/web-service/flaskapp/utilities.py
+++ b/source/web-service/flaskapp/utilities.py
@@ -225,6 +225,9 @@ def idPrefixer(attr, value, prefix=None, **kwargs):
 
 def requested_linkformat(request_obj, default_response_type):
     # application/json or application/link-format preferred?
+    # In cases where the client uses Accept: */*, the first item of the following
+    # accept list will be returned, hence the repeat of 'default_response_type' there.
     return request_obj.accept_mimetypes.best_match(
-        ["application/link-format", "application/json"], default=default_response_type
+        [default_response_type, "application/link-format", "application/json"],
+        default=default_response_type,
     )

--- a/source/web-service/flaskapp/utilities.py
+++ b/source/web-service/flaskapp/utilities.py
@@ -221,3 +221,10 @@ def idPrefixer(attr, value, prefix=None, **kwargs):
         temp = prefix + "/" + temp
 
     return temp
+
+
+def requested_linkformat(request_obj, default_response_type):
+    # application/json or application/link-format preferred?
+    return request_obj.accept_mimetypes.best_match(
+        ["application/link-format", "application/json"], default=default_response_type
+    )


### PR DESCRIPTION
There are more standard ways and libraries to handle and display JSON than link-format - most modern browsers display it well, and for a long time JSON version of the TimeMap was the default. This makes the preference configurable, whether the default TimeMap response is in JSON or application/link-format.

In any case, either format can be retrieved using suitable Accept headers in the request. This change only affects the response that is returned by default, or when an `Accept: */*` header is part of the request.