### PR TITLE
Update Orb to Version 3 – DEV-16254

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ anchors:
 
 orbs:
   docker: circleci/docker@1.5.0
-  getty-devops-release: thegetty/devops-orb@2
+  getty-devops-release: thegetty/devops-orb@3
 
 workflows:
   build:


### PR DESCRIPTION
Updated the Getty `devops-orb` to version 3.