### PR TITLE
Shifting to explicitly use /dev/shm for tmp space

### DIFF
--- a/source/web-service/startup.sh
+++ b/source/web-service/startup.sh
@@ -28,6 +28,7 @@ if [[ "$WORKER_CLASS" != "gevent" ]]; then
          --keep-alive ${KEEPALIVE} \
          --access-logfile '-' \
          --error-logfile '-' \
+         --worker-tmp-dir /dev/shm \
          wsgi:app
 	$@
 else
@@ -40,6 +41,7 @@ else
          --keep-alive ${KEEPALIVE} \
          --access-logfile '-' \
          --error-logfile '-' \
+         --worker-tmp-dir /dev/shm \
          wsgi:app
 	$@
 fi


### PR DESCRIPTION
ID Manager on staging was a *lot* more stable and performant with a /dev/shm RAM volume temp space rather than /tmp on AWS. There is no harm in specifying this here without allocating a RAM volume in the kubernetes chart as /dev/shm will be presented as a typical filesystem regardless. If a RAM volume is provided, it will take advantage of it.