### PR TITLE
Fix Activity Stream Responses for Records that Never Existed – DEV-17363

### DIFF
--- a/source/web-service/flaskapp/errors.py
+++ b/source/web-service/flaskapp/errors.py
@@ -51,7 +51,7 @@ status_db_save_error = status_nt(
 
 
 # Construct 'error response' object
-def construct_error_response(status, source=None):
+def construct_error_response(status, source: int = None, detail: str = None):
 
     err = {}
     err["status"] = status.code
@@ -62,6 +62,9 @@ def construct_error_response(status, source=None):
 
     err["title"] = status.title
     err["detail"] = status.detail
+    err["detail"] = (
+        detail or status.detail
+    )  # added support here for the optional `detail` kwarg
     err = [err]
     result = {"errors": err}
 

--- a/source/web-service/flaskapp/routes/records.py
+++ b/source/web-service/flaskapp/routes/records.py
@@ -838,19 +838,26 @@ def entity_record_activity_stream(entity_id):
     limit = current_app.config["ITEMS_PER_PAGE"]
     total_pages = str(math.ceil(count / limit))
 
-    data = {
-        "@context": "https://www.w3.org/ns/activitystreams",
-        "summary": current_app.config["AS_DESC"],
-        "type": "OrderedCollection",
-        "id": url_record(entity_id),
-        "totalItems": count,
-    }
+    if count == 0 and total_pages == "0":
+        response = construct_error_response(status_page_not_found)
+        return abort(response)
+    else:
+        data = {
+            "@context": "https://www.w3.org/ns/activitystreams",
+            "summary": current_app.config["AS_DESC"],
+            "type": "OrderedCollection",
+            "id": url_record(entity_id),
+            "totalItems": count,
+        }
 
-    data["first"] = {"id": url_record(entity_id, 1), "type": "OrderedCollectionPage"}
-    data["last"] = {
-        "id": url_record(entity_id, total_pages),
-        "type": "OrderedCollectionPage",
-    }
+        data["first"] = {
+            "id": url_record(entity_id, 1),
+            "type": "OrderedCollectionPage",
+        }
+        data["last"] = {
+            "id": url_record(entity_id, total_pages),
+            "type": "OrderedCollectionPage",
+        }
 
     return current_app.make_response(data)
 

--- a/source/web-service/flaskapp/routes/records.py
+++ b/source/web-service/flaskapp/routes/records.py
@@ -839,7 +839,10 @@ def entity_record_activity_stream(entity_id):
     total_pages = math.ceil(count / limit)
 
     if count == 0 and total_pages == 0:
-        response = construct_error_response(status_page_not_found)
+        response = construct_error_response(
+            status_page_not_found,
+            detail="An Activity Stream is only available for records that currently exist or previously existed",
+        )
         return abort(response)
     else:
         data = {

--- a/source/web-service/flaskapp/routes/records.py
+++ b/source/web-service/flaskapp/routes/records.py
@@ -836,9 +836,9 @@ def delete_entity_version(entity_id):
 def entity_record_activity_stream(entity_id):
     count = get_record_activities_count(entity_id)
     limit = current_app.config["ITEMS_PER_PAGE"]
-    total_pages = str(math.ceil(count / limit))
+    total_pages = math.ceil(count / limit)
 
-    if count == 0 and total_pages == "0":
+    if count == 0 and total_pages == 0:
         response = construct_error_response(status_page_not_found)
         return abort(response)
     else:

--- a/source/web-service/tests/test_routes_activity.py
+++ b/source/web-service/tests/test_routes_activity.py
@@ -344,6 +344,13 @@ class TestPageRoute:
         dt = datetime(2019, 11, 22, 13, 2, 53)
         assert format_datetime(dt) == "2019-11-22T13:02:53"
 
+    def test_doesnotexist_record_activity_stream(
+        self, client, sample_record_with_ids, test_db, namespace
+    ):
+        url = f"/{namespace}/doesnotexist/activity-stream"
+        response = client.get(url)
+        assert response.status_code == 404
+
 
 class TestItemRoute:
     def test_typical_functionality(self, client, sample_data, namespace):
@@ -405,11 +412,6 @@ class TestActivityRecord:
             records.url_activity("someactivityid")
             == f"{base_url}/activity-stream/someactivityid"
         )
-
-    def test_doesnotexist_record_activity_stream(self, client, namespace):
-        url = f"/{namespace}/doesnotexist/activity-stream"
-        response = client.get(url)
-        assert response.status_code == 404
 
 
 class TestTruncateActivityStream:

--- a/source/web-service/tests/test_routes_activity.py
+++ b/source/web-service/tests/test_routes_activity.py
@@ -344,6 +344,13 @@ class TestPageRoute:
         dt = datetime(2019, 11, 22, 13, 2, 53)
         assert format_datetime(dt) == "2019-11-22T13:02:53"
 
+    def test_doesnotexist_record_activity_stream(
+        self, client, sample_record_with_ids, test_db, namespace
+    ):
+        url = f"/{namespace}/doesnotexist/activity-stream"
+        response = client.get(url)
+        assert response.status_code == 404
+
 
 class TestItemRoute:
     def test_typical_functionality(self, client, sample_data, namespace):

--- a/source/web-service/tests/test_routes_activity.py
+++ b/source/web-service/tests/test_routes_activity.py
@@ -344,13 +344,6 @@ class TestPageRoute:
         dt = datetime(2019, 11, 22, 13, 2, 53)
         assert format_datetime(dt) == "2019-11-22T13:02:53"
 
-    def test_doesnotexist_record_activity_stream(
-        self, client, sample_record_with_ids, test_db, namespace
-    ):
-        url = f"/{namespace}/doesnotexist/activity-stream"
-        response = client.get(url)
-        assert response.status_code == 404
-
 
 class TestItemRoute:
     def test_typical_functionality(self, client, sample_data, namespace):
@@ -412,6 +405,11 @@ class TestActivityRecord:
             records.url_activity("someactivityid")
             == f"{base_url}/activity-stream/someactivityid"
         )
+
+    def test_doesnotexist_record_activity_stream(self, client, namespace):
+        url = f"/{namespace}/doesnotexist/activity-stream"
+        response = client.get(url)
+        assert response.status_code == 404
 
 
 class TestTruncateActivityStream:


### PR DESCRIPTION
Checked `total_pages` and `count` are `0` in entity Activity Stream, and constructed a `404 Not Found` error response accordingly.