### PR TITLE
Bugfix on subaddressing on deleted records

### DIFF
--- a/source/web-service/flaskapp/routes/records.py
+++ b/source/web-service/flaskapp/routes/records.py
@@ -223,7 +223,7 @@ def subaddressing_search(entity_id):
             .filter(Record.data != None)
             .one_or_none()
         )
-        if record is not None:
+        if record is not None and record.data:
             break
 
     if record is not None:
@@ -553,7 +553,6 @@ def entity_record(entity_id):
 # 'DELETE' method.
 @records.route("/<path:id>", methods=["DELETE"])
 def delete(id):
-
     # Authentication
     status = authenticate_bearer(request)
     if status != status_ok:
@@ -580,7 +579,6 @@ def delete(id):
 
             # Process RDF if applicable
             if current_app.config["PROCESS_RDF"] is True:
-
                 full_uri = f"{current_app.config['RDFidPrefix']}/{id}"
                 current_app.logger.debug(
                     f"Attempting to delete {full_uri} from graphstore"

--- a/source/web-service/flaskapp/routes/records.py
+++ b/source/web-service/flaskapp/routes/records.py
@@ -224,12 +224,11 @@ def subaddressing_search(entity_id):
             .one_or_none()
         )
         if record is not None and record.data:
+            subpart = _findobj(record.data, "id", entity_id)
+            if subpart is not None:
+                return (record, subpart)
+            # break out of the loop, failed to find sub part
             break
-
-    if record is not None:
-        subpart = _findobj(record.data, "id", entity_id)
-        if subpart is not None:
-            return (record, subpart)
 
     return (None, None)
 


### PR DESCRIPTION
Trying to get a subpath on a record that has been deleted fails when it should respond with HTTP 404 as expected. 

This is currently failing (HTTP 500) due to LOD Gateway keeping a record row in the DB when the item has been deleted, and the subaddressing routine not checking to make sure that the record has data (and is therefore not deleted).