### PR TITLE
Small auth cleanup

### DIFF
--- a/source/web-service/flaskapp/routes/health.py
+++ b/source/web-service/flaskapp/routes/health.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, current_app, abort
+from flask import Blueprint, current_app, abort, request
 
 from flaskapp.models import db
 from flaskapp.routes import ingest
@@ -6,7 +6,10 @@ from flaskapp.errors import (
     status_db_error,
     construct_error_response,
     status_graphstore_error,
+    status_ok,
 )
+
+from flaskapp.utilities import authenticate_bearer
 
 # Create a new "health_check" route blueprint
 health = Blueprint("health", __name__)
@@ -14,6 +17,32 @@ health = Blueprint("health", __name__)
 
 @health.route("/health", methods=["GET"])
 def healthcheck_get():
+    if health_db():
+        if current_app.config["PROCESS_RDF"] is True:
+            query_endpoint = current_app.config["SPARQL_QUERY_ENDPOINT"]
+            if health_graphstore(query_endpoint):
+                return "OK"
+            else:
+                response = construct_error_response(status_graphstore_error)
+                return abort(response)
+        else:
+            return "OK"
+    else:
+        response = construct_error_response(status_db_error)
+        return abort(response)
+
+
+@health.route("/authhealth", methods=["GET"])
+def authd_healthcheck_get():
+    # same as the normal healthcheck, but requires authentication. This will be a cheap
+    # way for a client to make sure that its authentication token is correct.
+
+    # Authentication. If fails, abort with 401
+    status = authenticate_bearer(request, current_app)
+    if status != status_ok:
+        response = construct_error_response(status)
+        return abort(response)
+
     if health_db():
         if current_app.config["PROCESS_RDF"] is True:
             query_endpoint = current_app.config["SPARQL_QUERY_ENDPOINT"]

--- a/source/web-service/flaskapp/routes/sparql.py
+++ b/source/web-service/flaskapp/routes/sparql.py
@@ -1,4 +1,3 @@
-import json
 import requests
 
 # timing
@@ -9,7 +8,6 @@ from flask import (
     current_app,
     request,
     abort,
-    jsonify,
     Response,
     make_response,
 )
@@ -18,9 +16,7 @@ from flaskapp.errors import (
     status_nt,
     status_graphstore_error,
     construct_error_response,
-    status_ok,
 )
-from flaskapp.routes.ingest import authenticate_bearer
 
 # Create a new "sparql" route blueprint
 sparql = Blueprint("sparql", __name__)

--- a/source/web-service/flaskapp/utilities.py
+++ b/source/web-service/flaskapp/utilities.py
@@ -7,7 +7,7 @@ import re
 
 from enum import Enum
 
-from flask.errors import status_wrong_auth_token, status_bad_auth_header, status_ok
+from flaskapp.errors import status_wrong_auth_token, status_bad_auth_header, status_ok
 
 
 # Enum with possible database events

--- a/source/web-service/flaskapp/utilities.py
+++ b/source/web-service/flaskapp/utilities.py
@@ -5,8 +5,9 @@ import traceback
 import sys
 import re
 
-from datetime import datetime
 from enum import Enum
+
+from flask.errors import status_wrong_auth_token, status_bad_auth_header, status_ok
 
 
 # Enum with possible database events
@@ -249,3 +250,33 @@ def wants_html(request_obj, default_response_type="text/html"):
         ],
         default=default_response_type,
     ) in ["text/html", "application/xhtml+xml"]
+
+
+# ### AUTHENTICATION FUNCTIONS ###
+def authenticate_bearer(request, current_app):
+    # For now return the same error for all failing scenarios
+    error = status_wrong_auth_token
+
+    # Get Authorization header token
+    auth_header = request.headers.get("Authorization")
+
+    # Return error if auth header is not present
+    if not auth_header:
+        return error
+
+    else:
+        # get method (Bearer) and token
+        try:
+            method, token = auth_header.split(maxsplit=1)
+        except ValueError:
+            return status_bad_auth_header
+
+        # check the method is correct
+        if method != "Bearer":
+            return error
+
+        # verify token
+        elif token != current_app.config["AUTH_TOKEN"]:
+            return error
+
+    return status_ok

--- a/source/web-service/tests/test_routes_health.py
+++ b/source/web-service/tests/test_routes_health.py
@@ -3,6 +3,13 @@ class TestHealthRoute:
         response = client.get(f"/{namespace}/health")
         assert response.status_code == 200
 
+    def test_auth_health_ok(self, client, namespace, test_db, auth_token):
+        response = client.get(
+            f"/{namespace}/authhealth",
+            headers={"Authorization": "Bearer " + auth_token},
+        )
+        assert response.status_code == 200
+
     def test_health_db_down(self, client, namespace, test_db):
         test_db.drop_all()
         response = client.get(f"/{namespace}/health")

--- a/source/web-service/tests/test_routes_ingest.py
+++ b/source/web-service/tests/test_routes_ingest.py
@@ -223,6 +223,47 @@ class TestIngestSuccess:
         data_resp = response.get_json()
         assert data_resp["person/12345"] == "null"
 
+    def test_ingest_updates(self, client_no_rdf, namespace, auth_token, test_db_no_rdf):
+        data = {"id": "person/54321", "name": "John", "age": 31, "city": "New York"}
+
+        # load one record:
+        _ = client_no_rdf.post(
+            f"/{namespace}/ingest",
+            data=json.dumps(data),
+            headers={"Authorization": "Bearer " + auth_token},
+        )
+
+        assert _assert_data_in_db("person/54321", city="New York", age=31)
+
+        # new data for same id
+        data = {"id": "person/54321", "name": "John", "age": 35, "city": "NJ"}
+
+        # load one record:
+        _ = client_no_rdf.post(
+            f"/{namespace}/ingest",
+            data=json.dumps(data),
+            headers={"Authorization": "Bearer " + auth_token},
+        )
+
+        assert _assert_data_in_db("person/54321", city="NJ", age=35)
+
+        # new data for same id
+        data = {
+            "id": "person/54321",
+            "name": "John",
+            "age": 45,
+            "city": "Portland, Oregon",
+        }
+
+        # load one record:
+        _ = client_no_rdf.post(
+            f"/{namespace}/ingest",
+            data=json.dumps(data),
+            headers={"Authorization": "Bearer " + auth_token},
+        )
+
+        assert _assert_data_in_db("person/54321", city="Portland, Oregon", age=45)
+
     def test_ingest_new_versions(
         self, client_no_rdf, namespace, auth_token, test_db_no_rdf
     ):

--- a/source/web-service/tests/test_routes_ingest.py
+++ b/source/web-service/tests/test_routes_ingest.py
@@ -145,12 +145,15 @@ class TestIngestErrors:
 
 def _assert_data_in_db(record_id, **kwargs):
     if obj := Record.query.filter_by(entity_id=record_id).one_or_none():
+        print("Found record, now testing keyword arguments")
         for k, v in kwargs.items():
             if obj.data[k] != v:
+                print(f"In key '{k}' - should be {v}, found {obj.data[k]} instead")
                 return False
         return True
     else:
         # Couldn't find record
+        print("Could not find record 'record_id'")
         return False
 
 


### PR DESCRIPTION
As part of digging into the LOD Gateway to try to find anywhere that there may be SQL transaction edge-cases to explain the lag of committing data, I refactored some of the authentication code to make it more normal. It should still be moved to a JWT or more structured authentication system but this is a reasonable first refactor.

Added a number of database-level checks to the ingest test, to doubly check that the db has been updated after each type of ingest (updates and creates).

Also added an authenticated health check, so that clients can test the connection with authentication. The current pattern is to send a blank request to /ingest and mark it as successful if the response is HTTP 422 which is not great. This would be much cleaner, especially in the logs.