### PR TITLE
Marking datetime when startup script starts + skip flask db upgrade on demand

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,9 @@ FLASK_ENV=production
 
 FLASK_RUN_PORT=5100
 
+# Whether to run the flask db upgrade command on startup:
+DB_UPGRADE_ON_START=true
+
 # Workers -> somewhere between 2-4 per core
 WEB_WORKERS=1
 

--- a/source/web-service/startup.sh
+++ b/source/web-service/startup.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 
-flask db upgrade 
+echo "$(date -Iseconds) Beginning application script"
+
+if [ "$DB_UPGRADE_ON_START" == "true" ]; then
+    echo "Attempting DB upgrade -"
+    flask db upgrade 
+fi
 
 # Worker type
 WORKER_CLASS="${WORKER_CLASS:-sync}"


### PR DESCRIPTION
There is not much of a way to monitor the script on startup, so adding a echo statement at the top to mark when the script is actually begun (after the Vault env injection step).

Also lets us control whether it attempts the flask db upgrade step via an env variable (DB_UPGRADE_ON_START) which would save a second or two.
