### PR TITLE
RDF prefixes used in 'id' fields should not be treated as relative URIs

### DIFF
--- a/source/web-service/flaskapp/base_graph_utils.py
+++ b/source/web-service/flaskapp/base_graph_utils.py
@@ -131,3 +131,19 @@ def base_graph_filter(basegraphobj, fqdn_id):
             "Failed to access record table - has the initial flask db upgrade been run?"
         )
         return set()
+
+
+def get_url_prefixes_from_context(context_json):
+    # Get the list of mapped prefixes (eg 'rdfs') from the context
+    # TODO - investigate caching this function as a later feature PR
+    # (only a handful of contexts are in use and the response will be the same.)
+    proc = jsonld.JsonLdProcessor()
+    options = {
+        "isFrame": False,
+        "keepFreeFloatingNodes": False,
+        "documentLoader": current_app.config["RDF_DOCLOADER"],
+        "extractAllScripts": False,
+        "processingMode": "json-ld-1.1",
+    }
+    mappings = proc.process_context({"mappings": {}}, context_json, options)["mappings"]
+    return {x for x in mappings if mappings[x]["_prefix"] == True}

--- a/source/web-service/flaskapp/routes/records.py
+++ b/source/web-service/flaskapp/routes/records.py
@@ -38,6 +38,7 @@ from flaskapp.errors import (
     status_ok,
 )
 from flaskapp.utilities import checksum_json, authenticate_bearer
+from flaskapp.base_graph_utils import get_url_prefixes_from_context
 
 import time
 
@@ -434,6 +435,9 @@ def entity_record(entity_id):
 
                 # Assume that id/@id choice used in the data is the same as the top level
                 attr = "@id" if "@id" in data else "id"
+                urlprefixes = None
+                if "@context" in data:
+                    urlprefixes = get_url_prefixes_from_context(data["@context"])
 
                 data = containerRecursiveCallback(
                     data=data,
@@ -441,6 +445,7 @@ def entity_record(entity_id):
                     callback=idPrefixer,
                     prefix=idPrefix,
                     recursive=recursive,
+                    urlprefixes=urlprefixes,
                 )
 
                 current_app.logger.debug(

--- a/source/web-service/flaskapp/utilities.py
+++ b/source/web-service/flaskapp/utilities.py
@@ -123,6 +123,7 @@ def containerRecursiveCallback(
     find=None,
     replace=None,
     prefix=None,
+    urlprefixes=None,
     suffix=None,
     callback=None,
     recursive=True,
@@ -172,6 +173,7 @@ def containerRecursiveCallback(
                     prefix=prefix,
                     suffix=suffix,
                     callback=callback,
+                    urlprefixes=urlprefixes,
                 )
             else:
                 if (attr == None or attr == key) and isinstance(val, str):
@@ -182,6 +184,7 @@ def containerRecursiveCallback(
                         replace=replace,
                         prefix=prefix,
                         suffix=suffix,
+                        urlprefixes=urlprefixes,
                     )
 
             data[key] = val
@@ -199,6 +202,7 @@ def containerRecursiveCallback(
                     prefix=prefix,
                     suffix=suffix,
                     callback=callback,
+                    urlprefixes=urlprefixes,
                 )
             else:
                 if (attr == None or attr == key) and isinstance(val, str):
@@ -209,6 +213,7 @@ def containerRecursiveCallback(
                         replace=replace,
                         prefix=prefix,
                         suffix=suffix,
+                        urlprefixes=urlprefixes,
                     )
 
             data[key] = val
@@ -216,11 +221,12 @@ def containerRecursiveCallback(
     return data
 
 
-def idPrefixer(attr, value, prefix=None, **kwargs):
+def idPrefixer(attr, value, prefix=None, urlprefixes=None, **kwargs):
     """Helper callback method to prefix non-prefixed JSON-LD document 'id' attributes"""
-
+    if urlprefixes is None:
+        urlprefixes = set()
     # prefix any relative uri with the prefix
-    if value.split(":")[0] not in ALLOWED_SCHEMES and prefix:
+    if value.split(":")[0] not in (ALLOWED_SCHEMES.union(urlprefixes)) and prefix:
         return prefix + "/" + value
 
     return value

--- a/source/web-service/tests/conftest.py
+++ b/source/web-service/tests/conftest.py
@@ -181,6 +181,36 @@ def sample_record_with_ids(test_db):
 
 
 @pytest.fixture
+def sample_rdfrecord_with_context(test_db):
+    def _sample_record():
+        record = Record(
+            entity_id=str(uuid4()),
+            entity_type="Object",
+            datetime_created=datetime(2020, 11, 22, 13, 2, 53),
+            datetime_updated=datetime(2020, 12, 18, 11, 22, 7),
+            data={
+                "@context": {
+                    "dc": "http://purl.org/dc/elements/1.1/",
+                    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+                    "_label": {"@id": "http://www.w3.org/2000/01/rdf-schema#label"},
+                },
+                "@id": "rdfsample1",
+                "rdfs:seeAlso": [
+                    {
+                        "_label": "This is a meaningless bit of data to test if the idprefixer leaves the id alone",
+                        "@id": "dc:description",
+                    },
+                ],
+            },
+        )
+        test_db.session.add(record)
+        test_db.session.commit()
+        return record
+
+    return _sample_record
+
+
+@pytest.fixture
 def linguisticobject():
     def _generator(name, id):
         return {

--- a/source/web-service/tests/test_routes_records.py
+++ b/source/web-service/tests/test_routes_records.py
@@ -148,6 +148,26 @@ class TestObtainRecord:
         assert "LOD Gateway" in response.headers["Server"]
         assert json.loads(response.data) == data
 
+    def test_prefix_record_w_rdf_prefixes(
+        self, sample_rdfrecord_with_context, client, namespace, current_app
+    ):
+        current_app.config["PREFIX_RECORD_IDS"] = "RECURSIVE"
+
+        response = client.get(
+            f"/{namespace}/{sample_rdfrecord_with_context['record'].entity_id}"
+        )
+
+        assert response.status_code == 200
+
+        data = response.get_json()
+        print(data)
+
+        # make sure the main relative id has been prefixed
+        assert not data["@id"].startswith("rdfsample1")
+
+        # make sure that the RDF prefixed IDs have been left alone.
+        assert data["rdfs:seeAlso"][0]["@id"] == "dc:description"
+
     def test_prefix_record_ids_none(
         self, sample_data_with_ids, client, namespace, current_app
     ):


### PR DESCRIPTION
eg consider this contrived JSON-LD:
```
{
    "@context": {
        "rdfs": "RDFS PREFIX",
        "_label": {"@id": "rdfs:label"}
    },
    "@id": "foo",
    ....
}
```

The IdPrefixer (which turns the relative 'object/123' strings into FQDNs by prefixing them with the server host+path) would turn the ` {"@id": "rdfs:label"}` in the context above into ` {"@id": "http://host/path/rdfs:label"}`

We rarely use RDF shorthand in the '@id' field so this is definitely an edge case, but an edge case we should handle.