### PR TITLE
Allow "@context" in a L1 LOD Gateway

### DIFF
--- a/source/web-service/flaskapp/routes/records.py
+++ b/source/web-service/flaskapp/routes/records.py
@@ -441,7 +441,7 @@ def entity_record(entity_id):
                 # Assume that id/@id choice used in the data is the same as the top level
                 attr = "@id" if "@id" in data else "id"
                 urlprefixes = None
-                if "@context" in data:
+                if current_app.config["PROCESS_RDF"] is True and "@context" in data:
                     urlprefixes = get_url_prefixes_from_context(data["@context"])
 
                 data = containerRecursiveCallback(

--- a/source/web-service/flaskapp/routes/records.py
+++ b/source/web-service/flaskapp/routes/records.py
@@ -285,7 +285,10 @@ def entity_record(entity_id):
                     "records.entity_record", entity_id=record.entity_id
                 )
                 current_app.logger.debug(f"{record.data['@context']}")
-                if "@context" in record.data:
+                if (
+                    current_app.config["PROCESS_RDF"] is True
+                    and "@context" in record.data
+                ):
                     subdata["@context"] = record.data["@context"]
 
         if record is None:

--- a/source/web-service/flaskapp/storage_utilities/graph.py
+++ b/source/web-service/flaskapp/storage_utilities/graph.py
@@ -36,9 +36,9 @@ class RetryAfterError(Exception):
 
 def inflate_relative_uris(data, id_attr="id"):
     idPrefix = current_app.config["RDFidPrefix"]
-    urlprefixes = []
+    urlprefixes = None
 
-    if "@context" in data:
+    if current_app.config["PROCESS_RDF"] is True and "@context" in data:
         # Get any context-added url prefixes:
         urlprefixes = get_url_prefixes_from_context(data["@context"])
 

--- a/source/web-service/tests/test_rdf_in_no_rdf_store.py
+++ b/source/web-service/tests/test_rdf_in_no_rdf_store.py
@@ -18,7 +18,7 @@ def _assert_data_in_db(record_id, **kwargs):
         return False
 
 
-class TestIngestSuccess:
+class TestIngestRDFinL1Success:
     def test_ingest_wcontext_and_retrieve(
         self, client_no_rdf, namespace, auth_token, test_db_no_rdf
     ):
@@ -27,7 +27,7 @@ class TestIngestSuccess:
             data=json.dumps(
                 {
                     "@context": "https://fakecontext.org/should/not/be/loaded",
-                    "id": "object/12345",
+                    "id": "object/12345_context",
                     "name": "John",
                     "age": 31,
                     "city": "New York",
@@ -38,4 +38,11 @@ class TestIngestSuccess:
         assert response.status_code == 200
         assert b"object/12345" in response.data
 
-        assert _assert_data_in_db("object/12345", name="John", age=31)
+        assert _assert_data_in_db("object/12345_context", name="John", age=31)
+
+        response = client_no_rdf.get(f"/{namespace}/object/12345_context")
+        assert response.status_code == 200
+        assert "LOD Gateway" in response.headers["Server"]
+
+        data = json.loads(response.data)
+        assert "@context" in data

--- a/source/web-service/tests/test_rdf_in_no_rdf_store.py
+++ b/source/web-service/tests/test_rdf_in_no_rdf_store.py
@@ -1,0 +1,41 @@
+import json
+
+from flaskapp.models import db
+from flaskapp.models.record import Record
+
+
+def _assert_data_in_db(record_id, **kwargs):
+    if obj := Record.query.filter_by(entity_id=record_id).one_or_none():
+        print("Found record, now testing keyword arguments")
+        for k, v in kwargs.items():
+            if obj.data[k] != v:
+                print(f"In key '{k}' - should be {v}, found {obj.data[k]} instead")
+                return False
+        return True
+    else:
+        # Couldn't find record
+        print("Could not find record 'record_id'")
+        return False
+
+
+class TestIngestSuccess:
+    def test_ingest_wcontext_and_retrieve(
+        self, client_no_rdf, namespace, auth_token, test_db_no_rdf
+    ):
+        response = client_no_rdf.post(
+            f"/{namespace}/ingest",
+            data=json.dumps(
+                {
+                    "@context": "https://fakecontext.org/should/not/be/loaded",
+                    "id": "object/12345",
+                    "name": "John",
+                    "age": 31,
+                    "city": "New York",
+                }
+            ),
+            headers={"Authorization": "Bearer " + auth_token},
+        )
+        assert response.status_code == 200
+        assert b"object/12345" in response.data
+
+        assert _assert_data_in_db("object/12345", name="John", age=31)


### PR DESCRIPTION
There were a few gaps that attempted to load a context using a document processor from PyLD even though PROCESS_RDF is set to False. This should clear those up.