### PR TITLE
Get version route to handle 'relativeids' flag as well

### DIFF
--- a/source/web-service/flaskapp/routes/records.py
+++ b/source/web-service/flaskapp/routes/records.py
@@ -683,10 +683,8 @@ def entity_version(entity_id):
                     request.values.get("relativeid", "").lower() in trueset
                     or prefixRecordIDs == "NONE"
                 ):  # when "NONE", record "id" field prefixing is not enabled
-                    # Use the subaddressing data if it has been set (and subaddressing is enabled)
-                    # Use record data otherwise
 
-                    # Don't allow format rewriting:
+                    # Don't allow format rewriting if the URIs are relative (ntriples, etc break):
                     allow_format_rewriting = False
                 else:  # otherwise, record "id" field prefixing is enabled, as configured
                     current_app.logger.debug(


### PR DESCRIPTION
Found out retrieve version route did not have the updated code to allow for the id prefixing to be turned off on request. (Useful to revert a resource to a previous version for instance.)