### PR TITLE
CircleCI Test - run test suite against Postgres 17.4 in addition

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,10 +158,6 @@ commands:
             black --check
             .
       - run:
-          name: Start PostgreSQL 17
-          command: |
-            docker run --name postgres -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=password -e POSTGRES_DB=mydatabase -p 5432:5432 -d postgres:17.4
-      - run:
           name: Testing PyLD using pytest - SQLite
           command: >
             docker run
@@ -190,31 +186,20 @@ commands:
             --cov-report html:/output/test-reports/pytest
       - run:
           name: Testing PyLD using pytest - Postgres 17.4
-          command: >
-            docker run
-            --env-file .env.example
-            --env DATABASE=postgresql://postgres:password@localhost:5432/mydatabase
-            --env APPLICATION_NAMESPACE="ns"
-            --volume /tmp/output:/output
-            << parameters.image>>:<< parameters.tag >>
-            pytest
-            --junitxml=/output/test-results/pytest/junit.xml
-            --cov=flaskapp
-            --cov-report html:/output/test-reports/pytest
+          command: |
+            docker network create testnetwork || true
+            docker run -d --network=testnetwork --name=postgresdb -p 5432:5432 -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=circle_test cimg/postgres:17.4
+            sleep 5
+            docker run --network=testnetwork --env-file .env.example --env DATABASE=postgresql://postgres:postgres@postgresdb:5432/circle_test --env APPLICATION_NAMESPACE="ns" --volume /tmp/output:/output << parameters.image>>:<< parameters.tag >> pytest --junitxml=/output/test-results/pytest/junit.xml --cov=flaskapp --cov-report html:/output/test-reports/pytest
+            docker network remove testnetwork || true
       - run:
           name: Testing RDFLib using pytest - Postgres 17.4
-          command: >
-            docker run
-            --env-file .env.example
-            --env DATABASE=postgresql://postgres:password@localhost:5432/mydatabase
-            --env APPLICATION_NAMESPACE="ns"
-            --env USE_PYLD_REFORMAT=false
-            --volume /tmp/output:/output
-            << parameters.image>>:<< parameters.tag >>
-            pytest
-            --junitxml=/output/test-results/pytest/junit.xml
-            --cov=flaskapp
-            --cov-report html:/output/test-reports/pytest
+          command:  |
+            docker network create testnetwork || true
+            docker run -d --network=testnetwork --name=postgresdb -p 5432:5432 -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=circle_test cimg/postgres:17.4
+            sleep 5
+            docker run --network=testnetwork --env-file .env.example --env USE_PYLD_REFORMAT=false --env DATABASE=postgresql://postgres:postgres@postgresdb:5432/circle_test --env APPLICATION_NAMESPACE="ns" --volume /tmp/output:/output << parameters.image>>:<< parameters.tag >> pytest --junitxml=/output/test-results/pytest/junit.xml --cov=flaskapp --cov-report html:/output/test-reports/pytest
+            docker network remove testnetwork || true
   store:
     steps:
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,6 @@ orbs:
   docker: circleci/docker@1.5.0
   getty-devops-release: thegetty/devops-orb@3
 
-
 workflows:
   build:
     jobs:
@@ -161,7 +160,7 @@ commands:
       - run:
           name: Start PostgreSQL 17
           command: |
-            docker run --name postgres -e POSTGRES_USER=postgres  -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=postgres -p 5432:5432 -d postgres:17.4
+            docker run --name postgres -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=password -e POSTGRES_DB=mydatabase -p 5432:5432 -d postgres:17.4
       - run:
           name: Testing PyLD using pytest - SQLite
           command: >
@@ -194,7 +193,7 @@ commands:
           command: >
             docker run
             --env-file .env.example
-            --env DATABASE=postgresql://postgres:postgres@localhost:5432/postgres
+            --env DATABASE=postgresql://postgres:password@localhost:5432/mydatabase
             --env APPLICATION_NAMESPACE="ns"
             --volume /tmp/output:/output
             << parameters.image>>:<< parameters.tag >>
@@ -207,7 +206,7 @@ commands:
           command: >
             docker run
             --env-file .env.example
-            --env DATABASE=postgresql://postgres:postgres@localhost:5432/postgres
+            --env DATABASE=postgresql://postgres:password@localhost:5432/mydatabase
             --env APPLICATION_NAMESPACE="ns"
             --env USE_PYLD_REFORMAT=false
             --volume /tmp/output:/output

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,7 +194,7 @@ commands:
           command: >
             docker run
             --env-file .env.example
-            --env DATABASE=postgresql://postgres:postgres@postgres/postgres
+            --env DATABASE=postgresql://postgres:postgres@localhost:5432/postgres
             --env APPLICATION_NAMESPACE="ns"
             --volume /tmp/output:/output
             << parameters.image>>:<< parameters.tag >>
@@ -207,7 +207,7 @@ commands:
           command: >
             docker run
             --env-file .env.example
-            --env DATABASE=postgresql://postgres:postgres@postgres/postgres
+            --env DATABASE=postgresql://postgres:postgres@localhost:5432/postgres
             --env APPLICATION_NAMESPACE="ns"
             --env USE_PYLD_REFORMAT=false
             --volume /tmp/output:/output

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,7 +159,11 @@ commands:
             black --check
             .
       - run:
-          name: Testing PyLD using pytest
+          name: Start PostgreSQL 17
+          command: |
+            docker run --name postgres -e POSTGRES_USER=postgres  -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=postgres -p 5432:5432 -d postgres:17.4
+      - run:
+          name: Testing PyLD using pytest - SQLite
           command: >
             docker run
             --env-file .env.example
@@ -172,7 +176,7 @@ commands:
             --cov=flaskapp
             --cov-report html:/output/test-reports/pytest
       - run:
-          name: Testing RDFLib using pytest
+          name: Testing RDFLib using pytest - SQLite
           command: >
             docker run
             --env-file .env.example
@@ -185,7 +189,33 @@ commands:
             --junitxml=/output/test-results/pytest/junit.xml
             --cov=flaskapp
             --cov-report html:/output/test-reports/pytest
-
+      - run:
+          name: Testing PyLD using pytest - Postgres 17.4
+          command: >
+            docker run
+            --env-file .env.example
+            --env DATABASE=postgresql://postgres:postgres@postgres/postgres
+            --env APPLICATION_NAMESPACE="ns"
+            --volume /tmp/output:/output
+            << parameters.image>>:<< parameters.tag >>
+            pytest
+            --junitxml=/output/test-results/pytest/junit.xml
+            --cov=flaskapp
+            --cov-report html:/output/test-reports/pytest
+      - run:
+          name: Testing RDFLib using pytest - Postgres 17.4
+          command: >
+            docker run
+            --env-file .env.example
+            --env DATABASE=postgresql://postgres:postgres@postgres/postgres
+            --env APPLICATION_NAMESPACE="ns"
+            --env USE_PYLD_REFORMAT=false
+            --volume /tmp/output:/output
+            << parameters.image>>:<< parameters.tag >>
+            pytest
+            --junitxml=/output/test-results/pytest/junit.xml
+            --cov=flaskapp
+            --cov-report html:/output/test-reports/pytest
   store:
     steps:
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,20 +185,22 @@ commands:
             --cov=flaskapp
             --cov-report html:/output/test-reports/pytest
       - run:
-          name: Testing PyLD using pytest - Postgres 17.4
+          name: Start Postgres 17.4 instance on testnetwork
           command: |
             docker network create testnetwork || true
             docker run -d --network=testnetwork --name=postgresdb -p 5432:5432 -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=circle_test cimg/postgres:17.4
             sleep 5
+      - run:
+          name: Testing PyLD using pytest - Postgres 17.4
+          command: |
             docker run --network=testnetwork --env-file .env.example --env DATABASE=postgresql://postgres:postgres@postgresdb:5432/circle_test --env APPLICATION_NAMESPACE="ns" --volume /tmp/output:/output << parameters.image>>:<< parameters.tag >> pytest --junitxml=/output/test-results/pytest/junit.xml --cov=flaskapp --cov-report html:/output/test-reports/pytest
-            docker network remove testnetwork || true
       - run:
           name: Testing RDFLib using pytest - Postgres 17.4
           command:  |
-            docker network create testnetwork || true
-            docker run -d --network=testnetwork --name=postgresdb -p 5432:5432 -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=circle_test cimg/postgres:17.4
-            sleep 5
             docker run --network=testnetwork --env-file .env.example --env USE_PYLD_REFORMAT=false --env DATABASE=postgresql://postgres:postgres@postgresdb:5432/circle_test --env APPLICATION_NAMESPACE="ns" --volume /tmp/output:/output << parameters.image>>:<< parameters.tag >> pytest --junitxml=/output/test-results/pytest/junit.xml --cov=flaskapp --cov-report html:/output/test-reports/pytest
+      - run:
+          name: Remove testnetwork if possible
+          command: |
             docker network remove testnetwork || true
   store:
     steps:

--- a/Dockerfile.db-service
+++ b/Dockerfile.db-service
@@ -1,5 +1,5 @@
 # See https://hub.docker.com/_/postgres
-FROM postgres:13.6
+FROM postgres:16.4
 
 RUN localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 ENV LANG en_US.utf8


### PR DESCRIPTION
This updates the CircleCI CI steps so that it runs the test suite in the following contexts:
- SQLite, PyLD
- SQLite, RDFLib
- Postgres 17.4, PyLD
- Postgres 17.4, RDFLib