### PR TITLE
Fix for weird issue with Nexus not able to resolve basic packages

### DIFF
--- a/Dockerfile.web-service
+++ b/Dockerfile.web-service
@@ -19,10 +19,10 @@ WORKDIR ${WHEELS}
 
 ARG NEXUS_USER
 ARG NEXUS_PASSWORD
-ARG PIP_INDEX_URL=https://${NEXUS_USER}:${NEXUS_PASSWORD}@artifacts.getty.edu/repository/jpgt-pypi-virtual/simple
+ARG NEXUS_INDEX_URL=https://${NEXUS_USER}:${NEXUS_PASSWORD}@artifacts.getty.edu/repository/jpgt-pypi-virtual/simple
 
 COPY requirements.txt requirements.txt
-RUN pip wheel --wheel-dir=${WHEELS} -r ${WHEELS}/requirements.txt
+RUN pip wheel --wheel-dir=${WHEELS} -r ${WHEELS}/requirements.txt --no-input --extra-index-url  ${NEXUS_INDEX_URL}
 
 FROM base AS runtime
 


### PR DESCRIPTION
Trying to clean room install a few things, and was getting very strange errors from pip trying to get authentication from a user when being run in docker compose build. Once I fixed that, the next error was that nexus did not have some basic packages, such as setuptools. 

```
#0 4.902   × pip subprocess to install build dependencies did not run successfully.
#0 4.902   │ exit code: 1
#0 4.902   ╰─> [3 lines of output]
#0 4.902       Looking in indexes: https://:****@artifacts.getty.edu/repository/jpgt-pypi-virtual/simple
#0 4.902       ERROR: Could not find a version that satisfies the requirement setuptools (from versions: none)
#0 4.902       ERROR: No matching distribution found for setuptools
#0 4.902       [end of output]
```

This PR uses Nexus repo as an extra package URL to work around the error. It may not be needed, as it could be something to do with the permissions changing for the nexus user/password but I am parking this here just in case.