### PR TITLE
Switching to use the now public gettysparqlpatterns

### DIFF
--- a/Dockerfile.web-service
+++ b/Dockerfile.web-service
@@ -17,10 +17,6 @@ FROM base AS buildenv
 
 WORKDIR ${WHEELS}
 
-ARG NEXUS_USER
-ARG NEXUS_PASSWORD
-ARG PIP_INDEX_URL=https://${NEXUS_USER}:${NEXUS_PASSWORD}@artifacts.getty.edu/repository/jpgt-pypi-virtual/simple
-
 COPY requirements.txt requirements.txt
 RUN pip wheel --wheel-dir=${WHEELS} -r ${WHEELS}/requirements.txt
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,9 +22,6 @@ services:
         build:
             context: ./
             dockerfile: ./Dockerfile.web-service
-            args:
-              NEXUS_USER: ${NEXUS_USER}
-              NEXUS_PASSWORD: ${NEXUS_PASSWORD}
         #command: flask db upgrade
         #command: flask run --host=0.0.0.0
         command: ./startup.sh

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ Flask-Migrate==4.1.0
 Flask-SQLAlchemy==3.1.1
 gevent==25.4.1 
 git+https://github.com/thegetty/pyld.git@threadlocking#egg=pyld
+gettysparqlpatterns @ https://github.com/thegetty/getty-jsonld-sparql-patterns/archive/refs/tags/v1.2.3.zip
 gunicorn==23.0.0
 ldap3==2.9
 psycopg2-binary>=2.9.10
@@ -22,3 +23,5 @@ regex==2022.3.2
 requests-mock==1.9.3
 requests>=2.32
 SQLAlchemy==2.0.40
+wheel
+setuptools


### PR DESCRIPTION
Adding the gettysparqlpatterns as a git dependency to load a specific release. wheel and setuptools are added to ensure a clean build.