### PR TITLE
Fuseki to 6.1.0

### DIFF
--- a/Dockerfile.sparql-service
+++ b/Dockerfile.sparql-service
@@ -1,7 +1,7 @@
 FROM eclipse-temurin:21-jdk
 
 # Set Fuseki version and environment variables
-ARG FUSEKI_VERSION=6.0.0
+ARG FUSEKI_VERSION=6.1.0
 
 # NB fuseki-config.ttl will also need to be updated to new DB location if this changes
 ENV FUSEKI_HOME=/opt/fuseki


### PR DESCRIPTION
Fuseki 6.0.0 seems to not be available anymore, so shifting to latest stable

NB The CI/CD does not test this, the Fuseki runtime is purely for local testing and deployment and is configured to behave similarly to the Neptune triplestore cluster LOD Gateways have when deployed to kubernetes. I was able to build the fuseki images locally, and run it.