### PR TITLE
Add optional authentication to SPARQL based on ENV flag

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ pytest-cov==3.0.0
 pytest-flask==1.3.0
 pytest-mock==3.14.0
 pytest-watch==4.2.0
-pytest==8.3.*
+pytest>=9.0.3,<10
 python-json-logger==2.0.7
 rdflib==6.3.2
 regex==2022.3.2

--- a/source/web-service/flaskapp/__init__.py
+++ b/source/web-service/flaskapp/__init__.py
@@ -161,12 +161,18 @@ def create_app():
     app.config["USE_PYLD_REFORMAT"] = True
     app.config["PROCESS_RDF"] = False
     app.config["CONTENT_PROFILE_PATTERNS_AVAILABLE"] = False
+    app.config["SPARQL_QUERY_AUTHENTICATION"] = False
 
     if environ.get("PROCESS_RDF", "False").lower() == "true":
         app.config["PROCESS_RDF"] = True
         app.logger.info("RDF processing is enabled")
         app.config["SPARQL_QUERY_ENDPOINT"] = environ["SPARQL_QUERY_ENDPOINT"]
         app.config["SPARQL_UPDATE_ENDPOINT"] = environ["SPARQL_UPDATE_ENDPOINT"]
+
+        # Add Authentication to SPARQL endpoint?
+        app.config["SPARQL_QUERY_AUTHENTICATION"] = (
+            environ.get("SPARQL_QUERY_AUTHENTICATION", "False").lower() == "true"
+        )
 
         # LDP Support (NB all dependent on PROCESS_RDF being true)
         # LDP_BACKEND -> This flag controls the backend bookkeeping where the container lists are kept
@@ -383,9 +389,9 @@ def create_app():
         # Needs the app context and the db to be initialized:
         if basegraph := environ.get("RDF_BASE_GRAPH"):
             app.config["RDF_BASE_GRAPH"] = basegraph
-            app.config["FULL_BASE_GRAPH"] = (
-                f'{app.config["BASE_URL"]}/{app.config["NAMESPACE_FOR_RDF"]}/{basegraph}'
-            )
+            app.config[
+                "FULL_BASE_GRAPH"
+            ] = f'{app.config["BASE_URL"]}/{app.config["NAMESPACE_FOR_RDF"]}/{basegraph}'
 
             app.config["RDF_FILTER_SET"] = base_graph_filter(
                 app.config["RDF_BASE_GRAPH"], app.config["FULL_BASE_GRAPH"]

--- a/source/web-service/flaskapp/__init__.py
+++ b/source/web-service/flaskapp/__init__.py
@@ -389,9 +389,9 @@ def create_app():
         # Needs the app context and the db to be initialized:
         if basegraph := environ.get("RDF_BASE_GRAPH"):
             app.config["RDF_BASE_GRAPH"] = basegraph
-            app.config[
-                "FULL_BASE_GRAPH"
-            ] = f'{app.config["BASE_URL"]}/{app.config["NAMESPACE_FOR_RDF"]}/{basegraph}'
+            app.config["FULL_BASE_GRAPH"] = (
+                f'{app.config["BASE_URL"]}/{app.config["NAMESPACE_FOR_RDF"]}/{basegraph}'
+            )
 
             app.config["RDF_FILTER_SET"] = base_graph_filter(
                 app.config["RDF_BASE_GRAPH"], app.config["FULL_BASE_GRAPH"]

--- a/source/web-service/flaskapp/routes/sparql.py
+++ b/source/web-service/flaskapp/routes/sparql.py
@@ -12,11 +12,16 @@ from flask import (
 
 from flaskapp.errors import (
     status_nt,
+    status_ok,
     construct_error_response,
     status_graphstore_timeout,
 )
 
-from flaskapp.utilities import execute_sparql_query_post, execute_sparql_query
+from flaskapp.utilities import (
+    execute_sparql_query_post,
+    execute_sparql_query,
+    authenticate_bearer,
+)
 
 # Create a new "sparql" route blueprint
 sparql = Blueprint("sparql", __name__)
@@ -34,6 +39,13 @@ def query_entrypoint():
             )
         )
         return abort(response)
+
+    if current_app.config["SPARQL_QUERY_AUTHENTICATION"] is True:
+        # SPARQL endpoint requires authentication
+        status = authenticate_bearer(request, current_app)
+        if status != status_ok:
+            response = construct_error_response(status)
+            return abort(response)
 
     if "update" in request.args or request.form.get("update") is not None:
         response = construct_error_response(

--- a/source/web-service/flaskapp/routes/yasgui.py
+++ b/source/web-service/flaskapp/routes/yasgui.py
@@ -1,5 +1,6 @@
-from flask import Blueprint, current_app, abort
-from flaskapp.errors import status_nt, construct_error_response
+from flask import Blueprint, current_app, abort, request
+from flaskapp.errors import status_nt, construct_error_response, status_ok
+from flaskapp.utilities import authenticate_bearer
 
 # Create a new "yasgui" route blueprint
 yasgui = Blueprint("yasgui", __name__)
@@ -24,28 +25,69 @@ def get_yasgui():
         + current_app.config["NAMESPACE"]
         + "/sparql"
     )
-    yasgui_page = create_yasgui_html(endpoint)
-    return yasgui_page
+
+    if current_app.config["SPARQL_QUERY_AUTHENTICATION"] is True:
+        # SPARQL endpoint requires authentication
+        status = authenticate_bearer(request, current_app)
+        if status != status_ok:
+            response = construct_error_response(status)
+            return abort(response)
+
+        auth_header = request.headers.get("Authorization")
+
+        # pass on the actual token from "Bearer <token>"
+        token = ""
+        if auth_header and auth_header.startswith("Bearer "):
+            token = auth_header.split(" ")[1]
+
+        # No authentication required.
+        yasgui_page = create_yasgui_html(endpoint, token=token)
+        return yasgui_page
+    else:
+        # No authentication required.
+        yasgui_page = create_yasgui_html(endpoint)
+        return yasgui_page
 
 
-def create_yasgui_html(endpoint):
+def create_yasgui_html(endpoint, token=None):
     head = (
         "<head>"
         "<link href='https://unpkg.com/@triply/yasgui/build/yasgui.min.css' rel='stylesheet' type='text/css' />"
         "<script src='https://unpkg.com/@triply/yasgui/build/yasgui.min.js'></script>"
         "</head>"
     )
-    body = (
-        "<body>"
-        "<div id='yasgui'></div>"
-        "<script>"
-        "const yasgui = new Yasgui(document.getElementById('yasgui'), "
-        "{requestConfig: { endpoint: "
-        f"'{endpoint}'"
-        "}, copyEndpointOnNewTab: false}); "
-        "</script>"
-        "<style> .yasgui .autocompleteWrapper { visibility: hidden } .yasr .tableControls .tableFilter { margin-right: 10px; height: auto !important; } </style>"
-        "</body>"
-    )
+
+    if token is not None:
+        body = (
+            "<body>"
+            "<div id='yasgui'></div>"
+            "<script>"
+            f"const serverToken = '{token}';"
+            "const yasgui = new Yasgui(document.getElementById('yasgui'), {"
+            "  requestConfig: {"
+            f"   endpoint: '{endpoint}',"
+            "    bearerAuth: {"
+            f"     token: '{token}'"
+            "    }"
+            "  },"
+            "  copyEndpointOnNewTab: false"
+            "});"
+            "</script>"
+            "<style> .yasgui .autocompleteWrapper { visibility: hidden } .yasr .tableControls .tableFilter { margin-right: 10px; height: auto !important; } </style>"
+            "</body>"
+        )
+    else:
+        body = (
+            "<body>"
+            "<div id='yasgui'></div>"
+            "<script>"
+            "const yasgui = new Yasgui(document.getElementById('yasgui'), "
+            "{requestConfig: { endpoint: "
+            f"'{endpoint}'"
+            "}, copyEndpointOnNewTab: false}); "
+            "</script>"
+            "<style> .yasgui .autocompleteWrapper { visibility: hidden } .yasr .tableControls .tableFilter { margin-right: 10px; height: auto !important; } </style>"
+            "</body>"
+        )
 
     return head + body

--- a/source/web-service/flaskapp/routes/yasgui.py
+++ b/source/web-service/flaskapp/routes/yasgui.py
@@ -40,7 +40,7 @@ def get_yasgui():
         if auth_header and auth_header.startswith("Bearer "):
             token = auth_header.split(" ")[1]
 
-        # No authentication required.
+        # /sparql queries requires token:
         yasgui_page = create_yasgui_html(endpoint, token=token)
         return yasgui_page
     else:

--- a/source/web-service/tests/test_routes_sparql.py
+++ b/source/web-service/tests/test_routes_sparql.py
@@ -39,10 +39,6 @@ class TestSparqlSuccess:
             client.application.config["SPARQL_QUERY_AUTHENTICATION"] = True
             response = client.get(
                 f"/{namespace}/sparql" + "?query=SELECT+*+%7B%3Fs+%3Fp+%3Fo%7D+LIMIT+1",
-                headers={
-                    "Authorization": "Bearer " + auth_token,
-                    "Accept": "application/json",
-                },
             )
             # Should be blocked with HTTP 401
             assert response.status_code == 401

--- a/source/web-service/tests/test_routes_sparql.py
+++ b/source/web-service/tests/test_routes_sparql.py
@@ -31,6 +31,35 @@ class TestSparqlSuccess:
         assert response.status_code == 200
         assert b"results" in response.data
 
+    def test_sparql_get_auth(self, client, namespace, auth_token, test_db):
+        original_value = client.application.config.get("SPARQL_QUERY_AUTHENTICATION")
+
+        try:
+            # Apply the temporary test config
+            client.application.config["SPARQL_QUERY_AUTHENTICATION"] = True
+            response = client.get(
+                f"/{namespace}/sparql" + "?query=SELECT+*+%7B%3Fs+%3Fp+%3Fo%7D+LIMIT+1",
+                headers={
+                    "Authorization": "Bearer " + auth_token,
+                    "Accept": "application/json",
+                },
+            )
+            # Should be blocked with HTTP 401
+            assert response.status_code == 401
+
+            response = client.get(
+                f"/{namespace}/sparql",
+                data={"query": "SELECT * {?s ?p ?o} LIMIT 1"},
+                headers={
+                    "Authorization": "Bearer " + auth_token,
+                    "Accept": "application/json",
+                },
+            )
+            assert response.status_code == 200
+        finally:
+            # Revert back to avoid breaking other tests
+            client.application.config["SPARQL_QUERY_AUTHENTICATION"] = original_value
+
     def test_sparql_post(self, client, namespace, auth_token, test_db):
         response = client.post(
             f"/{namespace}/sparql",


### PR DESCRIPTION
SPARQL_QUERY_AUTHENTICATION = true/false, requires exact match to "true" to enable, default is false.

When enabled, both /sparql and /sparql-ui routes are checked to see if the requesting user is authenticated, and if not, it will respond with a suitable error code.

It also adjusts the /sparql-ui yasgui interface to pass on the Bearer token when it queries /sparql when that token is present in the page request.