### PR TITLE
Trying to tell werkzeug not to enforce slashes

### DIFF
--- a/source/web-service/flaskapp/routes/records.py
+++ b/source/web-service/flaskapp/routes/records.py
@@ -328,8 +328,8 @@ def container_record(container_id, page=None):
         )
 
 
-@records.route("/<path:entity_id>/", methods=["POST"])
-@records.route("/", methods=["POST"], defaults={"entity_id": "/"})
+@records.route("/<path:entity_id>/", methods=["POST"], strict_slashes=False)
+@records.route("/", methods=["POST"], defaults={"entity_id": "/"}, strict_slashes=False)
 def container_post_item(entity_id):
     # Could be a resource or a container being POSTed to a target URI which has to be an existing container
     # Behavior will be as LDP states:
@@ -1234,7 +1234,6 @@ def entity_version(entity_id):
                     request.values.get("relativeid", "").lower() in trueset
                     or prefixRecordIDs == "NONE"
                 ):  # when "NONE", record "id" field prefixing is not enabled
-
                     # Don't allow format rewriting if the URIs are relative (ntriples, etc break):
                     allow_format_rewriting = False
                 else:  # otherwise, record "id" field prefixing is enabled, as configured

--- a/source/web-service/tests/test_routes_records.py
+++ b/source/web-service/tests/test_routes_records.py
@@ -16,6 +16,11 @@ class TestObtainRecord:
         assert "LOD Gateway" in response.headers["Server"]
         assert json.loads(response.data) == sample_data["record"].data
 
+    def test_typical_OPTIONS_on_asset(self, sample_data, client, namespace):
+        response = client.options(f"/{namespace}/{sample_data['record'].entity_id}")
+        assert response.status_code == 200
+        assert "LOD Gateway" in response.headers["Server"]
+
     def test_missing_record(self, sample_data, client, namespace):
         response = client.get(f"/{namespace}/object/no-record")
         assert response.status_code == 404


### PR DESCRIPTION
It could be the new version of Werkzeug being picky about slashes in the deployed state.