### PR TITLE
Adding Werkzeug ProxyFix as deploy option

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ workflows:
           name: "Deploy to Staging (Getty)"
           context: GETTY
           tag: *imageTag
-          service: lod-gateway-archivesspace-l1,lod-gateway-media-l2,lod-gateway-museum-collection-l2,lod-gateway-otmm-l1,lod-gateway-rcv-l2,lod-gateway-rosetta-l1,lod-gateway-vocab-l2,lod-gateway-thesaurus-l2,lod-gateway-annotations-l2,lod-gateway-tms-l1,lod-gateway-consonance-l1,lod-gateway-publications-l2,lod-gateway-publications-l2,lod-gateway-provenance-l2
+          service: lod-gateway-archivesspace-l1,lod-gateway-media-l2,lod-gateway-museum-collection-l2,lod-gateway-otmm-l1,lod-gateway-rcv-l2,lod-gateway-rosetta-l1,lod-gateway-vocab-l2,lod-gateway-thesaurus-l2,lod-gateway-annotations-l2,lod-gateway-tms-l1,lod-gateway-consonance-l1,lod-gateway-publications-l2,lod-gateway-provenance-l2
           requires:
             - build
             - "Publish to Getty ECR"
@@ -87,7 +87,7 @@ workflows:
           name: "Deploy to Prod (Getty)"
           context: GETTY
           tag: *imageTag
-          service: lod-gateway-archivesspace-l1,lod-gateway-media-l2,lod-gateway-museum-collection-l2,lod-gateway-otmm-l1,lod-gateway-rcv-l2,lod-gateway-rosetta-l1,lod-gateway-vocab-l2,lod-gateway-thesaurus-l2,lod-gateway-annotations-l2,lod-gateway-tms-l1,lod-gateway-consonance-l1,lod-gateway-publications-l2,lod-gateway-publications-l2,lod-gateway-provenance-l2
+          service: lod-gateway-archivesspace-l1,lod-gateway-media-l2,lod-gateway-museum-collection-l2,lod-gateway-otmm-l1,lod-gateway-rcv-l2,lod-gateway-rosetta-l1,lod-gateway-vocab-l2,lod-gateway-thesaurus-l2,lod-gateway-annotations-l2,lod-gateway-tms-l1,lod-gateway-consonance-l1,lod-gateway-publications-l2,lod-gateway-provenance-l2
           environment: prd
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ workflows:
           name: "Deploy to Staging (Getty)"
           context: GETTY
           tag: *imageTag
-          service: lod-gateway-archivesspace-l1,lod-gateway-media-l2,lod-gateway-museum-collection-l2,lod-gateway-otmm-l1,lod-gateway-rcv-l2,lod-gateway-rosetta-l1,lod-gateway-vocab-l2,lod-gateway-provenance-l2,lod-gateway-annotations-l2,lod-gateway-tms-l1,lod-gateway-consonance-l1,lod-gateway-thesaurus-l2
+          service: lod-gateway-archivesspace-l1,lod-gateway-media-l2,lod-gateway-museum-collection-l2,lod-gateway-otmm-l1,lod-gateway-rcv-l2,lod-gateway-rosetta-l1,lod-gateway-vocab-l2,lod-gateway-thesaurus-l2,lod-gateway-annotations-l2,lod-gateway-tms-l1,lod-gateway-consonance-l1,lod-gateway-publications-l2,lod-gateway-publications-l2,lod-gateway-provenance-l2
           requires:
             - build
             - "Publish to Getty ECR"
@@ -87,7 +87,7 @@ workflows:
           name: "Deploy to Prod (Getty)"
           context: GETTY
           tag: *imageTag
-          service: lod-gateway-archivesspace-l1,lod-gateway-media-l2,lod-gateway-museum-collection-l2,lod-gateway-otmm-l1,lod-gateway-rcv-l2,lod-gateway-rosetta-l1,lod-gateway-vocab-l2,lod-gateway-thesaurus-l2,lod-gateway-annotations-l2,lod-gateway-tms-l1,lod-gateway-consonance-l1
+          service: lod-gateway-archivesspace-l1,lod-gateway-media-l2,lod-gateway-museum-collection-l2,lod-gateway-otmm-l1,lod-gateway-rcv-l2,lod-gateway-rosetta-l1,lod-gateway-vocab-l2,lod-gateway-thesaurus-l2,lod-gateway-annotations-l2,lod-gateway-tms-l1,lod-gateway-consonance-l1,lod-gateway-publications-l2,lod-gateway-publications-l2,lod-gateway-provenance-l2
           environment: prd
           filters:
             branches:

--- a/.env.example
+++ b/.env.example
@@ -38,12 +38,13 @@ WORKER_CONNECTIONS=100
 
 # Werkzeug ProxyFix settings
 # There are some reverse-proxy quirks that can be smoothed out using
-# the following settings. 
-WERKZEUG_PROXY_FIX=false   # Needs to be true for any of the following
-#                            settings to take effect
+# the following settings.
+
+WERKZEUG_PROXY_FIX=false   
+# Needs to be true for any of the following settings to take effect
 
 WERKZEUG_X_FOR=1           # Use X-Forwarded-For from *TRUSTED* proxies or not
-WERKZEUG_X_PREFIX=0        # 0 Do not rewrite subpath of requests to be /
+WERKZEUG_X_PREFIX=1        # 0 Do not rewrite subpath of requests to be /
 WERKZEUG_X_HOST=1          # 1 Preserves the external domain name, 0 ignores.
 # Note x_proto is hardcoded to 1, so that url_for() generates http/https as requested.
 

--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,17 @@ EXTERNALHTTPCALLS_TIMELIMIT=45
 WORKER_CLASS=gevent
 WORKER_CONNECTIONS=100
 
+# Werkzeug ProxyFix settings
+# There are some reverse-proxy quirks that can be smoothed out using
+# the following settings. 
+WERKZEUG_PROXY_FIX=false   # Needs to be true for any of the following
+#                            settings to take effect
+
+WERKZEUG_X_FOR=1           # Use X-Forwarded-For from *TRUSTED* proxies or not
+WERKZEUG_X_PREFIX=0        # 0 Do not rewrite subpath of requests to be /
+WERKZEUG_X_HOST=1          # 1 Preserves the external domain name, 0 ignores.
+# Note x_proto is hardcoded to 1, so that url_for() generates http/https as requested.
+
 # Verbosity levels are CRITICAL, ERROR, WARNING, INFO, DEBUG
 DEBUG_LEVEL=INFO
 

--- a/source/web-service/flaskapp/__init__.py
+++ b/source/web-service/flaskapp/__init__.py
@@ -398,9 +398,9 @@ def create_app():
         # Needs the app context and the db to be initialized:
         if basegraph := environ.get("RDF_BASE_GRAPH"):
             app.config["RDF_BASE_GRAPH"] = basegraph
-            app.config[
-                "FULL_BASE_GRAPH"
-            ] = f'{app.config["BASE_URL"]}/{app.config["NAMESPACE_FOR_RDF"]}/{basegraph}'
+            app.config["FULL_BASE_GRAPH"] = (
+                f'{app.config["BASE_URL"]}/{app.config["NAMESPACE_FOR_RDF"]}/{basegraph}'
+            )
 
             app.config["RDF_FILTER_SET"] = base_graph_filter(
                 app.config["RDF_BASE_GRAPH"], app.config["FULL_BASE_GRAPH"]
@@ -505,7 +505,7 @@ def create_app():
                 x_proto=1,  # Ensures url_for() generates https:// instead of http:// if the original is https
                 x_host=X_HOST,  # Preserves the external domain name
                 x_for=X_FOR,  # 0 - Keeps internal IPs from polluting your logs, 1 - keep IPs passed from the proxy
-                x_prefix=X_PREFIX  # DISABLED: Unnecessary since internal and external paths match
+                x_prefix=X_PREFIX,  # DISABLED: Unnecessary since internal and external paths match
                 #    (eg external is ...edu/vocab/ and local is also served at /vocab/).
             )
         return app

--- a/source/web-service/flaskapp/__init__.py
+++ b/source/web-service/flaskapp/__init__.py
@@ -8,6 +8,8 @@ import requests
 from datetime import datetime
 import sqlite3
 
+from werkzeug.middleware.proxy_fix import ProxyFix
+
 from flask import Flask, Response
 from flask_cors import CORS
 from flask_migrate import Migrate
@@ -138,6 +140,13 @@ def create_app():
         # for Flask 2.3+
         app.config["JSON_SORT_KEYS"] = True
         app.json.sort_keys = True
+
+    # Strict Slashes - default to True as Werkzeug does
+    app.config["FLASK_STRICT_SLASHES"] = True
+    if "false" in environ.get("FLASK_STRICT_SLASHES", "true").lower():
+        app.config["FLASK_STRICT_SLASHES"] = False
+
+    app.url_map.strict_slashes = app.config["FLASK_STRICT_SLASHES"]
 
     app.config["ITEMS_PER_PAGE"] = 100
     app.config["AS_DESC"] = environ["LOD_AS_DESC"]
@@ -389,9 +398,9 @@ def create_app():
         # Needs the app context and the db to be initialized:
         if basegraph := environ.get("RDF_BASE_GRAPH"):
             app.config["RDF_BASE_GRAPH"] = basegraph
-            app.config["FULL_BASE_GRAPH"] = (
-                f'{app.config["BASE_URL"]}/{app.config["NAMESPACE_FOR_RDF"]}/{basegraph}'
-            )
+            app.config[
+                "FULL_BASE_GRAPH"
+            ] = f'{app.config["BASE_URL"]}/{app.config["NAMESPACE_FOR_RDF"]}/{basegraph}'
 
             app.config["RDF_FILTER_SET"] = base_graph_filter(
                 app.config["RDF_BASE_GRAPH"], app.config["FULL_BASE_GRAPH"]
@@ -461,4 +470,42 @@ def create_app():
 
             return response
 
+        if environ.get("WERKZEUG_PROXY_FIX", "true").lower() in ["true", "t", "1"]:
+            # Documentation: https://werkzeug.palletsprojects.com/en/stable/middleware/proxy_fix/
+
+            # NGINX-Ingress can be set to cluster or local (externalTrafficPolicy)
+            # If set to cluster, the IP address it passes along is the internal IP, not the client's one.
+            # If set to local (or using the use-proxy-protocol: "true" which might have unintended consequences, I don't know), client IPs should be passed on.
+
+            # X_FOR - 0 discard X-Forwarded-For and keep the NGINX/load balancer IP as the one to use, 1 - keep and use X-Forwarded-For
+            # If IP addresses are not passed on (cluster), either 0 or 1 produces the same behavior.
+
+            # Default: 1
+            X_FOR = 1
+            if environ.get("WERKZEUG_X_FOR", "0").lower() in ["0", 0, "n", "false"]:
+                X_FOR = 0
+
+            # X_PREFIX x_prefix=1 tells Werkzeug to look for the X-Forwarded-Prefix header
+            #    and use it to temporarily rewrite the application's root path (SCRIPT_NAME).
+
+            # Set to 0 to not do anything to the path before processing it.
+            X_PREFIX = 0
+            if environ.get("WERKZEUG_X_PREFIX", "0").lower() in ["1", 1, "y", "true"]:
+                X_PREFIX = 1
+
+            # Preserves the external domain name, 0 to not preserve it.
+            # Default: 1
+            X_HOST = 1
+            if environ.get("WERKZEUG_X_HOST", "0").lower() in ["0", 0, "n", "false"]:
+                X_HOST = 0
+
+            print("Applying Werkzeug Proxy Fixes")
+            app.wsgi_app = ProxyFix(
+                app.wsgi_app,
+                x_proto=1,  # Ensures url_for() generates https:// instead of http:// if the original is https
+                x_host=X_HOST,  # Preserves the external domain name
+                x_for=X_FOR,  # 0 - Keeps internal IPs from polluting your logs, 1 - keep IPs passed from the proxy
+                x_prefix=X_PREFIX  # DISABLED: Unnecessary since internal and external paths match
+                #    (eg external is ...edu/vocab/ and local is also served at /vocab/).
+            )
         return app

--- a/source/web-service/flaskapp/__init__.py
+++ b/source/web-service/flaskapp/__init__.py
@@ -63,6 +63,17 @@ logging.config.dictConfig(
 )
 
 
+def proxy_fix_wrap(app, x_for, x_host, x_prefix, x_proto=1):
+    app.wsgi_app = ProxyFix(
+        app.wsgi_app,
+        x_proto=1,  # Ensures url_for() generates https:// instead of http:// if the original is https
+        x_host=x_host,  # Preserves the external domain name
+        x_for=x_for,  # 0 - Keeps internal IPs from polluting your logs, 1 - keep IPs passed from the proxy
+        x_prefix=x_prefix,  # DISABLED: Unnecessary since internal and external paths match
+        #    (eg external is ...edu/vocab/ and local is also served at /vocab/).
+    )
+
+
 def create_app():
     app = Flask(__name__)
 
@@ -500,12 +511,6 @@ def create_app():
                 X_HOST = 0
 
             print("Applying Werkzeug Proxy Fixes")
-            app.wsgi_app = ProxyFix(
-                app.wsgi_app,
-                x_proto=1,  # Ensures url_for() generates https:// instead of http:// if the original is https
-                x_host=X_HOST,  # Preserves the external domain name
-                x_for=X_FOR,  # 0 - Keeps internal IPs from polluting your logs, 1 - keep IPs passed from the proxy
-                x_prefix=X_PREFIX,  # DISABLED: Unnecessary since internal and external paths match
-                #    (eg external is ...edu/vocab/ and local is also served at /vocab/).
-            )
+
+            proxy_fix_wrap(app, X_FOR, X_HOST, X_PREFIX, 1)
         return app

--- a/source/web-service/flaskapp/__init__.py
+++ b/source/web-service/flaskapp/__init__.py
@@ -481,7 +481,7 @@ def create_app():
 
             return response
 
-        if environ.get("WERKZEUG_PROXY_FIX", "true").lower() in ["true", "t", "1"]:
+        if environ.get("WERKZEUG_PROXY_FIX", "false").lower() in ["true", "t", "1"]:
             # Documentation: https://werkzeug.palletsprojects.com/en/stable/middleware/proxy_fix/
 
             # NGINX-Ingress can be set to cluster or local (externalTrafficPolicy)

--- a/source/web-service/startup.sh
+++ b/source/web-service/startup.sh
@@ -22,6 +22,9 @@ KEEPALIVE="${WEB_KEEPALIVE:-75}"
 
 FLASK_RUN_PORT="${FLASK_RUN_PORT:-5100}"
 
+# forwarded-allow-ips -> lets gunicorn trust various X- headers coming from NGINX. 
+# Cannot be tightended to an IP range or localhost as that isn't possible with the deployed environ
+
 # sync/threads? or green threads?
 if [[ "$WORKER_CLASS" != "gevent" ]]; then
 	echo "Running with either sync/gthreads - $WORKERS workers, $THREADS threads" && \
@@ -34,6 +37,7 @@ if [[ "$WORKER_CLASS" != "gevent" ]]; then
          --access-logfile '-' \
          --error-logfile '-' \
          --worker-tmp-dir /dev/shm \
+         --forwarded-allow-ips="*" \
          wsgi:app
 	$@
 else
@@ -47,6 +51,7 @@ else
          --access-logfile '-' \
          --error-logfile '-' \
          --worker-tmp-dir /dev/shm \
+         --forwarded-allow-ips="*" \
          wsgi:app
 	$@
 fi

--- a/source/web-service/tests/test_proxyfix.py
+++ b/source/web-service/tests/test_proxyfix.py
@@ -8,7 +8,7 @@ from flaskapp import create_app
 def make_client():
     def _make_client(enable_proxy):
         os.environ["WERKZEUG_PROXY_FIX"] = "true" if enable_proxy else "false"
-        os.environ["WERKZEUG_X_PREFIX"] = "1"
+        os.environ["WERKZEUG_X_PREFIX"] = "0"
         os.environ["WERKZEUG_X_FOR"] = "1"
         os.environ["WERKZEUG_X_HOST"] = "1"
 

--- a/source/web-service/tests/test_proxyfix.py
+++ b/source/web-service/tests/test_proxyfix.py
@@ -1,0 +1,59 @@
+import os
+import pytest
+from flask import url_for
+from flaskapp import create_app
+
+
+@pytest.fixture
+def make_client():
+    def _make_client(enable_proxy):
+        os.environ["WERKZEUG_PROXY_FIX"] = "true" if enable_proxy else "false"
+        os.environ["WERKZEUG_X_PREFIX"] = "0"
+        os.environ["WERKZEUG_X_FOR"] = "1"
+        os.environ["WERKZEUG_X_HOST"] = "1"
+
+        # import the Blueprint *before* app initialization
+        from flaskapp.routes.home_page import home_page
+
+        # inject the route directly into the blueprint just for the test
+        @home_page.route("/dynamic-test-route")
+        def dynamic_test_route():
+            # For blueprints, url_for requires the 'blueprint_name.view_name' syntax
+            return {"url": url_for("home_page.dynamic_test_route", _external=True)}
+
+        # 3. Initialize the app
+        app = create_app()
+        return app, app.test_client()
+
+    yield _make_client
+    os.environ.pop("WERKZEUG_PROXY_FIX", None)
+
+
+def test_proxy_fix_enabled(make_client):
+    app, client = make_client(enable_proxy=True)
+
+    namespace = app.config["NAMESPACE"]
+
+    response = client.get(
+        f"/{namespace}/dynamic-test-route",
+        headers={"X-Forwarded-Proto": "https", "X-Forwarded-Host": "example.com"},
+    )
+
+    assert response.json["url"] == f"https://example.com{namespace}/dynamic-test-route"
+
+
+def test_proxy_fix_disabled(make_client):
+    app, client = make_client(enable_proxy=False)
+
+    namespace = app.config["NAMESPACE"]
+
+    response = client.get(
+        f"/{namespace}/dynamic-test-route",
+        headers={"X-Forwarded-Proto": "https", "X-Forwarded-Host": "example.com"},
+    )
+
+    # Throws away the HTTPS PROTO header and redirects to HTTP:
+    assert response.json["url"].startswith("http://")
+
+    # Throws away the HOST header too.
+    assert "example.com" not in response.json["url"]

--- a/source/web-service/tests/test_proxyfix.py
+++ b/source/web-service/tests/test_proxyfix.py
@@ -5,7 +5,7 @@ from flask import Blueprint, url_for
 
 @pytest.fixture
 def make_client():
-    def _make_client(enable_proxy, app):
+    def _make_client(app, enable_proxy):
         os.environ["WERKZEUG_PROXY_FIX"] = "true" if enable_proxy else "false"
         os.environ["WERKZEUG_X_PREFIX"] = "0"
         os.environ["WERKZEUG_X_FOR"] = "1"
@@ -31,7 +31,7 @@ def make_client():
 
 
 def test_proxy_fix_enabled(app, make_client, test_db):
-    client = make_client(enable_proxy=True, app)
+    client = make_client(app, enable_proxy=True)
 
     namespace = app.config["NAMESPACE"]
 
@@ -67,7 +67,7 @@ def test_proxy_fix_enabled(app, make_client, test_db):
 
 
 def test_proxy_fix_disabled(app, make_client, test_db):
-    client = make_client(enable_proxy=False, app)
+    client = make_client(app, enable_proxy=False)
 
     namespace = app.config["NAMESPACE"]
 

--- a/source/web-service/tests/test_proxyfix.py
+++ b/source/web-service/tests/test_proxyfix.py
@@ -8,7 +8,7 @@ from flaskapp import create_app
 def make_client():
     def _make_client(enable_proxy):
         os.environ["WERKZEUG_PROXY_FIX"] = "true" if enable_proxy else "false"
-        os.environ["WERKZEUG_X_PREFIX"] = "0"
+        os.environ["WERKZEUG_X_PREFIX"] = "1"
         os.environ["WERKZEUG_X_FOR"] = "1"
         os.environ["WERKZEUG_X_HOST"] = "1"
 
@@ -46,7 +46,7 @@ def test_proxy_fix_enabled(make_client):
         },
     )
 
-    assert response.json["url"] == f"https://example.com{namespace}/dynamic-test-route"
+    assert response.json["url"] == f"https://example.com/{namespace}/dynamic-test-route"
 
 
 def test_proxy_fix_disabled(make_client):

--- a/source/web-service/tests/test_proxyfix.py
+++ b/source/web-service/tests/test_proxyfix.py
@@ -1,6 +1,6 @@
 import os
 import pytest
-from flask import url_for
+from flask import Blueprint, url_for
 from flaskapp import create_app
 
 
@@ -12,17 +12,21 @@ def make_client():
         os.environ["WERKZEUG_X_FOR"] = "1"
         os.environ["WERKZEUG_X_HOST"] = "1"
 
-        # import the Blueprint *before* app initialization
-        from flaskapp.routes.home_page import home_page
-
-        # inject the route directly into the blueprint just for the test
-        @home_page.route("/dynamic-test-route")
-        def dynamic_test_route():
-            # For blueprints, url_for requires the 'blueprint_name.view_name' syntax
-            return {"url": url_for("home_page.dynamic_test_route", _external=True)}
-
-        # 3. Initialize the app
+        # Initialize the app
         app = create_app()
+        namespace = app.config["NAMESPACE"]
+
+        # Now bolt on a new BL with a debug route
+        test_bp = Blueprint("proxy_test_bp", __name__)
+
+        @test_bp.route("/dynamic-test-route")
+        def dynamic_test_route():
+            # Targets the local test blueprint mapping
+            return {"url": url_for("proxy_test_bp.dynamic_test_route", _external=True)}
+
+        # 4. Register the new test blueprint using your production namespace pattern
+        app.register_blueprint(test_bp, url_prefix=f"/{namespace}")
+
         return app, app.test_client()
 
     yield _make_client
@@ -36,7 +40,10 @@ def test_proxy_fix_enabled(make_client):
 
     response = client.get(
         f"/{namespace}/dynamic-test-route",
-        headers={"X-Forwarded-Proto": "https", "X-Forwarded-Host": "example.com"},
+        headers={
+            "X-Forwarded-Proto": "https",
+            "X-Forwarded-Host": "example.com",
+        },
     )
 
     assert response.json["url"] == f"https://example.com{namespace}/dynamic-test-route"
@@ -49,7 +56,10 @@ def test_proxy_fix_disabled(make_client):
 
     response = client.get(
         f"/{namespace}/dynamic-test-route",
-        headers={"X-Forwarded-Proto": "https", "X-Forwarded-Host": "example.com"},
+        headers={
+            "X-Forwarded-Proto": "https",
+            "X-Forwarded-Host": "example.com",
+        },
     )
 
     # Throws away the HTTPS PROTO header and redirects to HTTP:

--- a/source/web-service/tests/test_proxyfix.py
+++ b/source/web-service/tests/test_proxyfix.py
@@ -24,7 +24,7 @@ def make_client():
         # 4. Register the new test blueprint using your production namespace pattern
         app.register_blueprint(test_bp, url_prefix=f"/{namespace}")
 
-        return app, app.test_client()
+        return app.test_client()
 
     yield _make_client
     os.environ.pop("WERKZEUG_PROXY_FIX", None)

--- a/source/web-service/tests/test_proxyfix.py
+++ b/source/web-service/tests/test_proxyfix.py
@@ -48,6 +48,26 @@ def test_proxy_fix_enabled(make_client):
 
     assert response.json["url"] == f"https://example.com/{namespace}/dynamic-test-route"
 
+    # Make sure some other plain routes still work fine:
+    response = client.get(
+        f"/{namespace}/dashboard",
+        headers={
+            "X-Forwarded-Proto": "https",
+            "X-Forwarded-Host": "example.com",
+        },
+    )
+    assert response.status_code == 200
+    assert b"LOD Gateway" in response.data
+
+    response = client.get(
+        f"/{namespace}/health",
+        headers={
+            "X-Forwarded-Proto": "https",
+            "X-Forwarded-Host": "example.com",
+        },
+    )
+    assert response.status_code == 200
+
 
 def test_proxy_fix_disabled(make_client):
     app, client = make_client(enable_proxy=False)

--- a/source/web-service/tests/test_proxyfix.py
+++ b/source/web-service/tests/test_proxyfix.py
@@ -90,7 +90,7 @@ def test_proxy_fix_disabled(make_client):
     )
 
     print(response.status_code)
-    print(response.content)
+    print(response.data.decode("utf-8"))
     print(response.headers)
 
     # Throws away the HTTPS PROTO header and redirects to HTTP:

--- a/source/web-service/tests/test_proxyfix.py
+++ b/source/web-service/tests/test_proxyfix.py
@@ -10,13 +10,13 @@ from flaskapp import proxy_fix_wrap
 def make_client(app, test_db):
     if not hasattr(app, "_original_wsgi_app"):
         app._original_wsgi_app = app.wsgi_app
+    else:
+        # reset needed?
+        app.wsgi_app = app._original_wsgi_app
 
     def _make_client(enable_proxy):
         if enable_proxy:
             os.environ["WERKZEUG_PROXY_FIX"] = "true"
-            os.environ["WERKZEUG_X_PREFIX"] = "0"
-            os.environ["WERKZEUG_X_FOR"] = "1"
-            os.environ["WERKZEUG_X_HOST"] = "1"
 
             proxy_fix_wrap(app, 1, 1, 0, 1)
 
@@ -36,7 +36,9 @@ def make_client(app, test_db):
         return app, app.test_client()
 
     yield _make_client
+
     app.wsgi_app = app._original_wsgi_app
+
     os.environ.pop("WERKZEUG_PROXY_FIX", None)
 
 

--- a/source/web-service/tests/test_proxyfix.py
+++ b/source/web-service/tests/test_proxyfix.py
@@ -1,19 +1,16 @@
 import os
 import pytest
 from flask import Blueprint, url_for
-from flaskapp import create_app
 
 
 @pytest.fixture
 def make_client():
-    def _make_client(enable_proxy):
+    def _make_client(enable_proxy, app):
         os.environ["WERKZEUG_PROXY_FIX"] = "true" if enable_proxy else "false"
         os.environ["WERKZEUG_X_PREFIX"] = "0"
         os.environ["WERKZEUG_X_FOR"] = "1"
         os.environ["WERKZEUG_X_HOST"] = "1"
 
-        # Initialize the app
-        app = create_app()
         namespace = app.config["NAMESPACE"]
 
         # Now bolt on a new BL with a debug route
@@ -33,8 +30,8 @@ def make_client():
     os.environ.pop("WERKZEUG_PROXY_FIX", None)
 
 
-def test_proxy_fix_enabled(make_client):
-    app, client = make_client(enable_proxy=True)
+def test_proxy_fix_enabled(app, make_client, test_db):
+    client = make_client(enable_proxy=True, app)
 
     namespace = app.config["NAMESPACE"]
 
@@ -69,8 +66,8 @@ def test_proxy_fix_enabled(make_client):
     assert response.status_code == 200
 
 
-def test_proxy_fix_disabled(make_client):
-    app, client = make_client(enable_proxy=False)
+def test_proxy_fix_disabled(app, make_client, test_db):
+    client = make_client(enable_proxy=False, app)
 
     namespace = app.config["NAMESPACE"]
 

--- a/source/web-service/tests/test_proxyfix.py
+++ b/source/web-service/tests/test_proxyfix.py
@@ -2,18 +2,27 @@ import os
 import pytest
 from flask import Blueprint, url_for
 
+# to reuse the same logic as the app would do.
+from flaskapp import proxy_fix_wrap
+
 
 @pytest.fixture
-def make_client():
-    def _make_client(app, enable_proxy):
-        os.environ["WERKZEUG_PROXY_FIX"] = "true" if enable_proxy else "false"
-        os.environ["WERKZEUG_X_PREFIX"] = "0"
-        os.environ["WERKZEUG_X_FOR"] = "1"
-        os.environ["WERKZEUG_X_HOST"] = "1"
+def make_client(app, test_db):
+    if not hasattr(app, "_original_wsgi_app"):
+        app._original_wsgi_app = app.wsgi_app
+
+    def _make_client(enable_proxy):
+        if enable_proxy:
+            os.environ["WERKZEUG_PROXY_FIX"] = "true"
+            os.environ["WERKZEUG_X_PREFIX"] = "0"
+            os.environ["WERKZEUG_X_FOR"] = "1"
+            os.environ["WERKZEUG_X_HOST"] = "1"
+
+            proxy_fix_wrap(app, 1, 1, 0, 1)
 
         namespace = app.config["NAMESPACE"]
 
-        # Now bolt on a new BL with a debug route
+        # bolt on a new BL with a debug route regardless
         test_bp = Blueprint("proxy_test_bp", __name__)
 
         @test_bp.route("/dynamic-test-route")
@@ -24,14 +33,15 @@ def make_client():
         # Register the new test blueprint using your namespace
         app.register_blueprint(test_bp, url_prefix=f"/{namespace}")
 
-        return app.test_client()
+        return app, app.test_client()
 
     yield _make_client
+    app.wsgi_app = app._original_wsgi_app
     os.environ.pop("WERKZEUG_PROXY_FIX", None)
 
 
-def test_proxy_fix_enabled(app, make_client, test_db):
-    client = make_client(app, enable_proxy=True)
+def test_proxy_fix_enabled(make_client):
+    app, client = make_client(enable_proxy=True)
 
     namespace = app.config["NAMESPACE"]
 
@@ -66,8 +76,8 @@ def test_proxy_fix_enabled(app, make_client, test_db):
     assert response.status_code == 200
 
 
-def test_proxy_fix_disabled(app, make_client, test_db):
-    client = make_client(app, enable_proxy=False)
+def test_proxy_fix_disabled(make_client):
+    app, client = make_client(enable_proxy=False)
 
     namespace = app.config["NAMESPACE"]
 

--- a/source/web-service/tests/test_proxyfix.py
+++ b/source/web-service/tests/test_proxyfix.py
@@ -79,6 +79,10 @@ def test_proxy_fix_disabled(app, make_client, test_db):
         },
     )
 
+    print(response.status_code)
+    print(response.content)
+    print(response.headers)
+
     # Throws away the HTTPS PROTO header and redirects to HTTP:
     assert response.json["url"].startswith("http://")
 

--- a/source/web-service/tests/test_proxyfix.py
+++ b/source/web-service/tests/test_proxyfix.py
@@ -21,7 +21,7 @@ def make_client():
             # Targets the local test blueprint mapping
             return {"url": url_for("proxy_test_bp.dynamic_test_route", _external=True)}
 
-        # 4. Register the new test blueprint using your production namespace pattern
+        # Register the new test blueprint using your namespace
         app.register_blueprint(test_bp, url_prefix=f"/{namespace}")
 
         return app.test_client()


### PR DESCRIPTION
- Added global FLASK_STRICT_SLASHES option to get ALL routes to use strict_slashes behavior, to stop Werkzeug stepping over the mark.
- Adds Werkzeug ProxyFix middleware to better handle some reverse proxy headers so that the redirects work as intended. Specifically, one issue is that the redirect did not honor the 'https/http' part of the request, and defaulted to 'http' for all.

WERKZEUG_PROXY_FIX=false   # Needs to be true for any of the following settings to take effect

WERKZEUG_X_FOR=1           # Use X-Forwarded-For from *TRUSTED* proxies or not
WERKZEUG_X_PREFIX=0        # 0 Do not rewrite subpath of requests to be /
WERKZEUG_X_HOST=1          # 1 Preserves the external domain name, 0 ignores.