### PR TITLE
Switching to Flask-OpenAPI3 to get a swagger/OpenAPI UI/declaration

### DIFF
--- a/.env.standalonetest
+++ b/.env.standalonetest
@@ -1,0 +1,141 @@
+# Configuration for a standalone test
+LOD_AS_DESC=Getty Activity Stream (Example)
+
+# HOST and Namespace (subpath) configuration:
+BASE_URL=http://localhost:5100
+APPLICATION_NAMESPACE=ns
+RDF_NAMESPACE=ns
+
+DATABASE=sqlite:///
+
+FLASK_GZIP_COMPRESSION=True
+FLASK_APP=/app/flaskapp
+FLASK_ENV=production
+
+FLASK_RUN_PORT=5100
+
+# Whether to run the flask db upgrade command on startup:
+DB_UPGRADE_ON_START=true
+
+# Workers -> somewhere between 2-4 per core
+WEB_WORKERS=1
+
+# I've seen values from 90 to 900 for deployed cloud-based services
+# which is far in excess of the defaults. Using 600 as a default
+WEB_TIMEOUT=600
+
+# SPARQL backend and some context lookups use requests library. 
+# The following var sets the default timeout for these calls
+EXTERNALHTTPCALLS_TIMELIMIT=45
+
+# Can be deployed using worker/threads model (sync/gthreads) or geventlet
+
+# threads -> 2-4, depending on type of typical load/DB load
+# WORKER_CLASS=gthreads
+# WEB_THREADS=2
+
+# gevent
+WORKER_CLASS=gevent
+WORKER_CONNECTIONS=100
+
+# Verbosity levels are CRITICAL, ERROR, WARNING, INFO, DEBUG
+DEBUG_LEVEL=INFO
+
+# JSON formatted logging, or false for standard?
+JSON_LOGGING=false
+
+# Also format the access logs as json? false to leave as normal
+ACCESS_JSON_LOGGING=false
+
+# Auth Token setup:
+AUTHORIZATION_TOKEN=AuthToken
+
+# RDF related configuration:
+PROCESS_RDF=True
+SPARQL_QUERY_ENDPOINT=http://fuseki:3030/ds/sparql
+SPARQL_UPDATE_ENDPOINT=http://fuseki:3030/ds/update
+
+# Use PyLD for parsing/reformatting JSON-LD?
+# Set to False to use RDFLib instead.
+USE_PYLD_REFORMAT=True
+
+# Base graph functionality:
+## Name of basegraph object:
+#RDF_BASE_GRAPH=
+
+## FOR TESTING ONLY! Reload basegraph if ingested (will only affect worker that handles the ingest!)
+## Base graph changes should be handled by updating the resource and then reloading the service fully
+TESTMODE_BASEGRAPH=False
+
+##### Versioning #####
+KEEP_LAST_VERSION=True
+# Keep even after deletion? Returns 404 for the times it is gone.
+KEEP_VERSIONS_AFTER_DELETION=False
+# Do users need to authenticate to see old versions?
+VERSIONING_AUTHENTICATION=True
+# Memento TimeMap format default: (application/json or application/link-format)
+MEMENTO_PREFERRED_FORMAT=application/link-format
+
+##### JSON output options #####
+JSON_SORT_KEYS=False
+JSON_AS_ASCII=False
+# Prefix search page size:
+ITEMS_PER_PAGE=100
+
+##### Sub-addressing resolving #####
+SUBADDRESSING=True
+
+##### Linked Data Platform flags #####
+
+# Crucial setting, all other LDP functionality is predicated on this one.
+LDP_BACKEND=True
+
+# Optional but recommended - causes the backend to automatically create
+# ldp:BasicContainer resources when necessitated by ingesting a resource to a subpath
+LDP_AUTOCREATE_CONTAINERS=True
+
+# Only turned this off if performance starts to take a hit with LDP_AUTOCREATE_CONTAINERS
+# and this checking step is taking too much of drain unnecessarily
+LDP_VALIDATE_SLUGS=True
+
+# This controls the support for LDP API hooks, response headers and endpoints
+LDP_API=False
+
+# This controls the size of the 'slice' taken from the Container's list of resources
+LDP_PAGE_SIZE=200
+
+# Sets the method by which items without a top level ID can gain one. Currently only uuid is supported
+LDP_ID_GEN=uuid
+
+##### Prefixing flags #####
+
+# Add prefix to relative IDs in resources
+# Can use GET param '?relativeid=true' to skip prefixing on request
+PREFIX_RECORD_IDS=RECURSIVE
+
+# Id prefixing will not prefix any RDF shorthand URIs (eg 'rdfs:label') in the `id`/`@id` property
+# It does this by resolving the context, if present, and getting the list of prefixes to ignore 
+# NB this only affects prefixes used with a colon (eg 'rdf:type' will be skipped if 'rdf' is in the context but
+# 'rdf/type' will be prefixed by the server's host and subpath as normal.)
+# The prefixes for a given context will be cached for a number of seconds (default 12 hours as below):
+CONTEXTPREFIX_TTL=43200
+
+# RDF Context Cache
+## LOD Gateway runs a cache for context documents, defaulting to 30 minutes in cache per context
+RDF_CONTEXT_CACHE_EXPIRES=30
+## This can be prefilled by RDF_CONTEXT_CACHE (in JSON encoding). See 'document_loader' notes in the base_graph_utils.py module for details.
+# eg:
+# RDF_CONTEXT_CACHE={"https://linked.art/ns/v1/linked-art.json": {"expires": null, "contextUrl": null, "documentUrl": null, "document": {"@context": {"@version": 1.1, "crm": "http://www.cidoc-crm.org/cidoc-crm/", "sci": "http://www.ics.forth.gr/isl/CRMsci/" .....
+
+# Content Profile information
+# CONTENT_PROFILE_DATA_URL=  .. url to the JSON-encoded PatternSet export for the profile SPARQL patterns
+# Or, instead of retrieving it from a URL resourse, it can be given in the following variable as
+# a JSON-encoded string.
+# CONTENT_PROFILE_DATA = '{"name": "...   ...    }'
+
+# The following profile is used for testing:
+# NB docker --env-file does not do shell expansions, but docker compose referencing
+# a .env file DOES. Very annoying.
+# When defining environment variables in a file to be used with docker run --env-file, avoid quoting values unless you explicitly intend for the quotes to be part of the variable's content. If a value contains spaces or special characters, simply define it without quotes, as Docker will treat the entire string after the = as the value.
+
+CONTENT_PROFILE_DATA={"name": "Simplified Dublin Core", "description": "No description given.", "url": "https://raw.githubusercontent.com/thegetty/getty-jsonld-sparql-patterns/refs/heads/main/src/gettysparqlpatterns/data/crmtodublincore.json", "patterns": [{"name": "InformationObject as DC", "description": "Views a CRM InformationObject in terms of Simplified Dublin Core", "sparql_pattern": "# MOCKED DCMI RESPONSE\nPREFIX aat: <http://vocab.getty.edu/aat/>\nPREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>\nPREFIX dc: <http://purl.org/dc/elements/1.1/>\nPREFIX dcterm: <http://purl.org/dc/terms/>\nPREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>\n\n\nCONSTRUCT {\n  <$URI> dc:identifier ?identifier ;\n     dc:title ?title ;\n     dc:description ?note ;\n     dc:creator ?agent_name ;\n     dc:date ?date_range ;\n     dc:date ?date_expression ;\n     dc:language ?lang ;\n     dc:language ?lang_as_text ;\n     dc:subject ?subject .\n  ?subject rdfs:label ?subject_text .\n  \n}\nWHERE {\nSELECT ?identifier ?title ?note ?subject ?subject_text ?date_range ?date_expression ?lang_as_text ?lang ?agent_name\n    WHERE {\n  GRAPH <$URI> {\n  <$URI> crm:P1_is_identified_by ?id_block .\n  ?id_block crm:P2_has_type ?id_type ;\n            crm:P190_has_symbolic_content ?identifier_text \n    BIND(CONCAT(?identifier_text, \" (\", STR(?id_type), \")\") as ?identifier) .\n  <$URI> rdfs:label ?title .\n      OPTIONAL {\n       <$URI> crm:P72_has_language ?lang .\n        ?lang rdfs:label ?lang_as_text\n      }\n     OPTIONAL {\n  <$URI> crm:P129_is_about ?subject .\n        ?subject a crm:E33_Linguistic_Object ;\n            rdfs:label ?subject_text\n      }\n      OPTIONAL {\n   <$URI> crm:P67i_is_referred_to_by ?notes .\n      ?notes crm:P2_has_type ?note_type ;\n            crm:P190_has_symbolic_content ?note_text \n      BIND(CONCAT(\"(\", STR(?note_type), \") \", ?note_text) as ?note) .\n      }\n      OPTIONAL {\n        ?prod_act a crm:E12_Production ;\n            OPTIONAL {\n        \t?prod_act  crm:P9_consists_of ?activities .\n            ?activities crm:P14_carried_out_by ?agent .\n            ?agent rdfs:label ?agent_name .\n        }\n        OPTIONAL {\n          ?prod_act crm:P4_has_time-span ?timespan .\n          ?timespan crm:P82a_begin_of_the_begin ?begin ;\n    \t\t\t    crm:P82b_end_of_the_end ?end \n          OPTIONAL {\n        BIND(CONCAT(STR(?begin), \" - \", STR(?end)) as ?date_range)\n         ?timespan crm:P1_is_identified_by ?expression .\n         ?expression a crm:E33_E41_Linguistic_Appellation ;\n    \t\t\t\t   crm:P190_has_symbolic_content ?date_expression ;\n        }\n      }\n      }\n  }\n}\n}", "stype": "construct", "keyword_parameters": ["URI"], "default_values": {}, "applies_to": ["InformationObject"], "ask_filter": null, "framing": null, "profile_uri": "urn:getty:dublincore"}, {"name": "LinguisticObject to dublincore", "description": "No description given", "sparql_pattern": "PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>\nPREFIX dc: <http://purl.org/dc/elements/1.1/>\nPREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>\nCONSTRUCT {\n  <$URI> dc:title ?title ;\n         dc:description ?content ;\n         dc:type ?type ;\n         dc:type ?type_name .\n} WHERE {\n SELECT ?title ?content ?type ?type_name WHERE {\n    <$URI> a crm:E33_Linguistic_Object ;\n           rdfs:label ?title ;\n           crm:P2_has_type ?type ;\n           crm:P190_has_symbolic_content ?content .\n    ?type rdfs:label ?type_name .\n  }\n}", "stype": "construct", "keyword_parameters": ["URI"], "default_values": {}, "applies_to": ["LinguisticObject"], "ask_filter": null, "framing": null, "profile_uri": "urn:getty:dublincore"}]}

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ _*
 !.dockerignore
 !.editorconfig
 !.env.example
+!.env.standalonetest
 *.pyc
 
 # Config files

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ Flask==3.1.*
 Flask-Compress==1.14
 Flask-Cors==5.0.*
 Flask-Migrate==4.1.0
+flask-openapi3[swagger]>=4.3.0,<5.0
 Flask-SQLAlchemy==3.1.1
 gevent==25.4.1 
 git+https://github.com/thegetty/pyld.git@threadlocking#egg=pyld

--- a/source/web-service/flaskapp/__init__.py
+++ b/source/web-service/flaskapp/__init__.py
@@ -490,18 +490,21 @@ def create_app():
             f"LOD Gateway will serve from a base of '{app.config['idPrefix']}"
         )
 
-        app.register_api(home_page, url_prefix=f"/{ns}")
-        app.register_api(activity, url_prefix=f"/{ns}")
-        app.register_api(activity_entity, url_prefix=f"/{ns}")
-        app.register_api(records, url_prefix=f"/{ns}")
-        app.register_api(ingest, url_prefix=f"/{ns}")
-        app.register_api(sparql, url_prefix=f"/{ns}")
-        app.register_api(yasgui, url_prefix=f"/{ns}")
-        app.register_api(timegate, url_prefix=f"/{ns}")
-        app.register_api(health, url_prefix=f"/{ns}")
+        nsprefix = f"/{ns}"
+        if nsprefix == "//":
+            nsprefix = "/"
+        app.register_api(home_page, url_prefix=nsprefix)
+        app.register_api(activity, url_prefix=nsprefix)
+        app.register_api(activity_entity, url_prefix=nsprefix)
+        app.register_api(records, url_prefix=nsprefix)
+        app.register_api(ingest, url_prefix=nsprefix)
+        app.register_api(sparql, url_prefix=nsprefix)
+        app.register_api(yasgui, url_prefix=nsprefix)
+        app.register_api(timegate, url_prefix=nsprefix)
+        app.register_api(health, url_prefix=nsprefix)
 
         # Non-JSON formatted payload patch for the OpenAPI
-        patch_ingest_route(app, ns)
+        patch_ingest_route(app, nsprefix)
 
         app.logger.info("LOD Gateway configured and ready for use")
 

--- a/source/web-service/flaskapp/__init__.py
+++ b/source/web-service/flaskapp/__init__.py
@@ -9,6 +9,8 @@ from datetime import datetime
 import sqlite3
 
 from flask import Flask, Response
+from flask_openapi3.openapi import OpenAPI
+from flask_openapi3 import Info
 from flask_cors import CORS
 from flask_migrate import Migrate
 from flask_compress import Compress
@@ -80,12 +82,24 @@ def create_app():
     from flask_openapi3.scaffold import _validate_request as original_validate_request
 
     def _patched_validate_request(
-        header=None, cookie=None, path=None, query=None, form=None, body=None,
-        raw=None, path_kwargs=None,
+        header=None,
+        cookie=None,
+        path=None,
+        query=None,
+        form=None,
+        body=None,
+        raw=None,
+        path_kwargs=None,
     ):
         func_kwargs = original_validate_request(
-            header=header, cookie=cookie, path=path,
-            query=query, form=form, body=body, raw=raw, path_kwargs=path_kwargs,
+            header=header,
+            cookie=cookie,
+            path=path,
+            query=query,
+            form=form,
+            body=body,
+            raw=raw,
+            path_kwargs=path_kwargs,
         )
         if not path and path_kwargs:
             func_kwargs.update(path_kwargs)
@@ -93,7 +107,12 @@ def create_app():
 
     scaffold._validate_request = _patched_validate_request
 
-    app = Flask(__name__)
+    lod_desc = environ.get("LOD_AS_DESC", "LOD Gateway")
+    app = OpenAPI(
+        __name__,
+        info=Info(title=lod_desc, version="1.0.0"),
+        doc_ui=True,
+    )
 
     app.config["DEBUG_LEVEL"] = getenv("DEBUG_LEVEL", "INFO")
     app.config["FLASK_ENV"] = getenv("FLASK_ENV", "production")
@@ -461,15 +480,15 @@ def create_app():
             f"LOD Gateway will serve from a base of '{app.config['idPrefix']}"
         )
 
-        app.register_blueprint(home_page, url_prefix=f"/{ns}")
-        app.register_blueprint(activity, url_prefix=f"/{ns}")
-        app.register_blueprint(activity_entity, url_prefix=f"/{ns}")
-        app.register_blueprint(records, url_prefix=f"/{ns}")
-        app.register_blueprint(ingest, url_prefix=f"/{ns}")
-        app.register_blueprint(sparql, url_prefix=f"/{ns}")
-        app.register_blueprint(yasgui, url_prefix=f"/{ns}")
-        app.register_blueprint(timegate, url_prefix=f"/{ns}")
-        app.register_blueprint(health, url_prefix=f"/{ns}")
+        app.register_api(home_page, url_prefix=f"/{ns}")
+        app.register_api(activity, url_prefix=f"/{ns}")
+        app.register_api(activity_entity, url_prefix=f"/{ns}")
+        app.register_api(records, url_prefix=f"/{ns}")
+        app.register_api(ingest, url_prefix=f"/{ns}")
+        app.register_api(sparql, url_prefix=f"/{ns}")
+        app.register_api(yasgui, url_prefix=f"/{ns}")
+        app.register_api(timegate, url_prefix=f"/{ns}")
+        app.register_api(health, url_prefix=f"/{ns}")
 
         app.logger.info("LOD Gateway configured and ready for use")
 

--- a/source/web-service/flaskapp/__init__.py
+++ b/source/web-service/flaskapp/__init__.py
@@ -437,9 +437,9 @@ def create_app():
         # Needs the app context and the db to be initialized:
         if basegraph := environ.get("RDF_BASE_GRAPH"):
             app.config["RDF_BASE_GRAPH"] = basegraph
-            app.config[
-                "FULL_BASE_GRAPH"
-            ] = f'{app.config["BASE_URL"]}/{app.config["NAMESPACE_FOR_RDF"]}/{basegraph}'
+            app.config["FULL_BASE_GRAPH"] = (
+                f'{app.config["BASE_URL"]}/{app.config["NAMESPACE_FOR_RDF"]}/{basegraph}'
+            )
 
             app.config["RDF_FILTER_SET"] = base_graph_filter(
                 app.config["RDF_BASE_GRAPH"], app.config["FULL_BASE_GRAPH"]

--- a/source/web-service/flaskapp/__init__.py
+++ b/source/web-service/flaskapp/__init__.py
@@ -11,6 +11,10 @@ import sqlite3
 from flask import Flask, Response
 from flask_openapi3.openapi import OpenAPI
 from flask_openapi3 import Info
+from flask_openapi3.models import SecurityScheme
+
+from flaskapp.openapi_models import patch_ingest_route
+
 from flask_cors import CORS
 from flask_migrate import Migrate
 from flask_compress import Compress
@@ -105,11 +109,19 @@ def create_app():
     if subpath == "/":
         subpath = ""
 
+    # Define security configuration:
+    bearer_scheme = SecurityScheme(
+        type="http", scheme="bearer", bearerFormat="Opaque"  # just a plain token
+    )
+
+    security_schemes = {"bearerAuth": bearer_scheme}
+
     app = OpenAPI(
         __name__,
         info=Info(title=lod_desc, version="1.0.0"),
         doc_ui=True,
         doc_prefix=f"/{subpath}/openapi",
+        security_schemes=security_schemes,
     )
 
     app.config["DEBUG_LEVEL"] = getenv("DEBUG_LEVEL", "INFO")
@@ -487,6 +499,9 @@ def create_app():
         app.register_api(yasgui, url_prefix=f"/{ns}")
         app.register_api(timegate, url_prefix=f"/{ns}")
         app.register_api(health, url_prefix=f"/{ns}")
+
+        # Non-JSON formatted payload patch for the OpenAPI
+        patch_ingest_route(app, ns)
 
         app.logger.info("LOD Gateway configured and ready for use")
 

--- a/source/web-service/flaskapp/__init__.py
+++ b/source/web-service/flaskapp/__init__.py
@@ -98,10 +98,18 @@ def create_app():
     scaffold._validate_request = _patched_validate_request
 
     lod_desc = environ.get("LOD_AS_DESC", "LOD Gateway")
+
+    # Get the subpath at which this is being served:
+    subpath = environ["APPLICATION_NAMESPACE"] or ""
+
+    if subpath == "/":
+        subpath = ""
+
     app = OpenAPI(
         __name__,
         info=Info(title=lod_desc, version="1.0.0"),
         doc_ui=True,
+        doc_prefix=f"/{subpath}/openapi",
     )
 
     app.config["DEBUG_LEVEL"] = getenv("DEBUG_LEVEL", "INFO")
@@ -429,9 +437,9 @@ def create_app():
         # Needs the app context and the db to be initialized:
         if basegraph := environ.get("RDF_BASE_GRAPH"):
             app.config["RDF_BASE_GRAPH"] = basegraph
-            app.config["FULL_BASE_GRAPH"] = (
-                f'{app.config["BASE_URL"]}/{app.config["NAMESPACE_FOR_RDF"]}/{basegraph}'
-            )
+            app.config[
+                "FULL_BASE_GRAPH"
+            ] = f'{app.config["BASE_URL"]}/{app.config["NAMESPACE_FOR_RDF"]}/{basegraph}'
 
             app.config["RDF_FILTER_SET"] = base_graph_filter(
                 app.config["RDF_BASE_GRAPH"], app.config["FULL_BASE_GRAPH"]

--- a/source/web-service/flaskapp/__init__.py
+++ b/source/web-service/flaskapp/__init__.py
@@ -62,6 +62,37 @@ logging.config.dictConfig(
 
 
 def create_app():
+    # Monkey-patch flask-openapi3's _validate_request to pass path_kwargs through
+    # when there's no path model. This fixes @bp.get() losing path parameters.
+    #
+    # Flask-OpenAPI3 4.x expects path parameters to be declared as a pydantic
+    # BaseModel annotated with `path: Type[BaseModel]`. When such a model is present,
+    # _validate_request() validates URL path parameters against the model and passes
+    # the validated object to the function. However, when no path model is provided
+    # (which is the common case for simple Flask-style routes like def route(entity_id)),
+    # _validate_request() returns an empty func_kwargs dict, discarding the path
+    # parameters that Flask correctly extracted from the URL rule.
+    #
+    # This gap means @bp.get("/<entity_id>") silently drops the entity_id argument.
+    # The patch bridges this by merging path_kwargs into func_kwargs when no path
+    # model is defined, preserving Flask's native parameter passing behavior.
+    from flask_openapi3 import scaffold
+    from flask_openapi3.scaffold import _validate_request as original_validate_request
+
+    def _patched_validate_request(
+        header=None, cookie=None, path=None, query=None, form=None, body=None,
+        raw=None, path_kwargs=None,
+    ):
+        func_kwargs = original_validate_request(
+            header=header, cookie=cookie, path=path,
+            query=query, form=form, body=body, raw=raw, path_kwargs=path_kwargs,
+        )
+        if not path and path_kwargs:
+            func_kwargs.update(path_kwargs)
+        return func_kwargs
+
+    scaffold._validate_request = _patched_validate_request
+
     app = Flask(__name__)
 
     app.config["DEBUG_LEVEL"] = getenv("DEBUG_LEVEL", "INFO")

--- a/source/web-service/flaskapp/__init__.py
+++ b/source/web-service/flaskapp/__init__.py
@@ -64,20 +64,10 @@ logging.config.dictConfig(
 
 
 def create_app():
-    # Monkey-patch flask-openapi3's _validate_request to pass path_kwargs through
-    # when there's no path model. This fixes @bp.get() losing path parameters.
-    #
-    # Flask-OpenAPI3 4.x expects path parameters to be declared as a pydantic
-    # BaseModel annotated with `path: Type[BaseModel]`. When such a model is present,
-    # _validate_request() validates URL path parameters against the model and passes
-    # the validated object to the function. However, when no path model is provided
-    # (which is the common case for simple Flask-style routes like def route(entity_id)),
-    # _validate_request() returns an empty func_kwargs dict, discarding the path
-    # parameters that Flask correctly extracted from the URL rule.
-    #
-    # This gap means @bp.get("/<entity_id>") silently drops the entity_id argument.
-    # The patch bridges this by merging path_kwargs into func_kwargs when no path
-    # model is defined, preserving Flask's native parameter passing behavior.
+    # Monkey-patch flask-openapi3's _validate_request to pass path_kwargs through.
+    # Flask-OpenAPI3 returns the validated path model as {'path': Model(...)} which
+    # doesn't unpack into individual route params. Passing path_kwargs ensures the
+    # route function receives actual parameters like entity_id, version, etc.
     from flask_openapi3 import scaffold
     from flask_openapi3.scaffold import _validate_request as original_validate_request
 
@@ -101,7 +91,7 @@ def create_app():
             raw=raw,
             path_kwargs=path_kwargs,
         )
-        if not path and path_kwargs:
+        if path_kwargs:
             func_kwargs.update(path_kwargs)
         return func_kwargs
 

--- a/source/web-service/flaskapp/openapi.py
+++ b/source/web-service/flaskapp/openapi.py
@@ -1,0 +1,57 @@
+"""Pydantic response schemas and tag definitions for OpenAPI docs.
+
+Used by route decorators across all blueprints. The OpenAPI spec is
+auto-generated from the @app.get() / @app.post() decorators on each
+blueprint's route functions.
+"""
+
+from pydantic import BaseModel
+from flask_openapi3 import Tag
+
+# ---------------------------------------------------------------------------
+# Tags (groupings for Swagger UI sidebar)
+# ---------------------------------------------------------------------------
+
+health_tag = Tag(name="health", description="Health-check endpoints")
+records_tag = Tag(name="records", description="Record CRUD operations")
+ingest_tag = Tag(name="ingest", description="Batch ingest endpoint")
+activity_tag = Tag(name="activity", description="Activity Stream endpoints")
+sparql_tag = Tag(name="sparql", description="SPARQL query endpoint")
+timegate_tag = Tag(name="timegate", description="Memento versioning endpoints")
+home_tag = Tag(name="home", description="Home page and dashboard")
+ldp_tag = Tag(name="ldp", description="Linked Data Platform endpoints")
+
+TAGS = [
+    health_tag,
+    records_tag,
+    ingest_tag,
+    activity_tag,
+    sparql_tag,
+    timegate_tag,
+    home_tag,
+    ldp_tag,
+]
+
+# ---------------------------------------------------------------------------
+# Response schemas
+# ---------------------------------------------------------------------------
+
+
+class HealthOK(BaseModel):
+    """Successful health-check response (plain text "OK")."""
+
+    pass
+
+
+class ErrorDetail(BaseModel):
+    """Single error item in an errors array."""
+
+    status: int
+    title: str
+    detail: str
+
+
+class ErrorResponse(BaseModel):
+    """Standard error response wrapper."""
+
+    errors: list[ErrorDetail]

--- a/source/web-service/flaskapp/openapi_models.py
+++ b/source/web-service/flaskapp/openapi_models.py
@@ -7,45 +7,69 @@ Each model defines a single path parameter matching a Flask URL rule converter
 (e.g. ``<path:entity_id>`` -> ``entity_id: str``, ``<int:pagenum>`` -> ``pagenum: int``).
 """
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
+from datetime import datetime
+from uuid import UUID
 
 
+# 1. Base Models with validation constraints applied via Field
 class EntityIdPath(BaseModel):
-    entity_id: str
+    entity_id: str = Field(
+        ...,
+        description="The relative identifier for a JSON object held in the LOD Gateway.",
+    )
 
 
 class IdPath(BaseModel):
-    id: str
+    id: str = Field(
+        ...,
+        description="The relative identifier for a JSON object held in the LOD Gateway.",
+    )
 
 
 class PagenumPath(BaseModel):
-    pagenum: int
-
-
-class PagenumStrPath(BaseModel):
-    pagenum: str
+    pagenum: int = Field(
+        ..., ge=1, description="The page number. Starts at 1 with no upper bound."
+    )
 
 
 class UuidPath(BaseModel):
-    uuid: str
+    # Using Pydantic's native UUID type auto-validates format and updates Swagger UI
+    uuid: UUID = Field(..., description="A valid Universally Unique Identifier (UUID).")
 
 
 class EntityTypePath(BaseModel):
-    entity_type: str
+    entity_type: str = Field(
+        ..., max_length=200, description="The type designation string of the entity."
+    )
 
 
 class TargetDatetimePath(BaseModel):
-    target_datetime: str
+    # If the endpoint expects an ISO string, using native datetime parses it
+    # correctly. If it must remain a raw string, use str with a datetime format description.
+    target_datetime: datetime = Field(
+        ..., description="The target timestamp (ISO 8601 format)."
+    )
 
 
+# 2. Composite Models combining the validated parameters
 class EntityTypePagenumPath(BaseModel):
-    entity_type: str
-    pagenum: str
+    entity_type: str = Field(
+        ..., max_length=200, description="The type designation string of the entity."
+    )
+    pagenum: int = Field(
+        ..., ge=1, description="The page number. Starts at 1 with no upper bound."
+    )
 
 
 class EntityIdActivityStreamPagenumPath(BaseModel):
-    entity_id: str
-    pagenum: int
+    entity_id: str = Field(
+        ...,
+        description="The relative identifier for a JSON object held in the LOD Gateway.",
+    )
+    pagenum: int = Field(
+        ..., ge=1, description="The page number. Starts at 1 with no upper bound."
+    )
 
 
 # OpenAPI decorator kwargs that should be stripped before passing to Flask's add_url_rule

--- a/source/web-service/flaskapp/openapi_models.py
+++ b/source/web-service/flaskapp/openapi_models.py
@@ -45,7 +45,7 @@ class EntityTypePagenumPath(BaseModel):
 
 class EntityIdActivityStreamPagenumPath(BaseModel):
     entity_id: str
-    pagenum: str
+    pagenum: int
 
 
 # OpenAPI decorator kwargs that should be stripped before passing to Flask's add_url_rule

--- a/source/web-service/flaskapp/openapi_models.py
+++ b/source/web-service/flaskapp/openapi_models.py
@@ -8,8 +8,33 @@ Each model defines a single path parameter matching a Flask URL rule converter
 """
 
 from pydantic import BaseModel, Field
-from datetime import datetime
 from uuid import UUID
+from typing import Optional
+
+
+# Example of a query model for GET parameters:
+# class EntityFiltersQuery(BaseModel):
+#     # Optional parameter with a default fallback value
+#     limit: int = Field(
+#         default=10,
+#         ge=1,
+#         le=100,
+#         description="Number of results to return per page."
+#     )
+
+#     # Optional parameter that defaults to None if not provided
+#     status: Optional[str] = Field(
+#         default=None,
+#         max_length=50,
+#         description="Filter entities by their operational status."
+#     )
+
+#     # Optional parameter with character length constraints
+#     search_term: Optional[str] = Field(
+#         default=None,
+#         min_length=3,
+#         description="Text search query against entity names."
+#     )
 
 
 # 1. Base Models with validation constraints applied via Field
@@ -47,8 +72,21 @@ class EntityTypePath(BaseModel):
 class TargetDatetimePath(BaseModel):
     # If the endpoint expects an ISO string, using native datetime parses it
     # correctly. If it must remain a raw string, use str with a datetime format description.
-    target_datetime: datetime = Field(
+    target_datetime: str = Field(
         ..., description="The target timestamp (ISO 8601 format)."
+    )
+
+
+class OptionalTargetDatetimePath(BaseModel):
+    target_datetime: Optional[str] = Field(
+        ..., description="The target timestamp (ISO 8601 format)."
+    )
+
+
+class OptionalTargetDatetimeQuery(BaseModel):
+    datetime: Optional[str] = Field(
+        ...,
+        description="The target timestamp (ISO 8601 format) from a '?datetime=' parameter",
     )
 
 

--- a/source/web-service/flaskapp/openapi_models.py
+++ b/source/web-service/flaskapp/openapi_models.py
@@ -135,6 +135,13 @@ class EntityIdPath(BaseModel):
     )
 
 
+class ContainerIdPath(BaseModel):
+    container_id: str = Field(
+        ...,
+        description="The relative path for an LDP Container.",
+    )
+
+
 class PagenumPath(BaseModel):
     pagenum: int = Field(
         ..., ge=1, description="The page number. Starts at 1 with no upper bound."

--- a/source/web-service/flaskapp/openapi_models.py
+++ b/source/web-service/flaskapp/openapi_models.py
@@ -1,0 +1,95 @@
+"""Pydantic path parameter models for Flask-OpenAPI3.
+
+These models are passed as the `path=` argument to @bp.get() / @bp.post()
+decorators so that Flask-OpenAPI3 can generate correct OpenAPI path parameters.
+
+Each model defines a single path parameter matching a Flask URL rule converter
+(e.g. ``<path:entity_id>`` -> ``entity_id: str``, ``<int:pagenum>`` -> ``pagenum: int``).
+"""
+
+from pydantic import BaseModel
+
+
+class EntityIdPath(BaseModel):
+    entity_id: str
+
+
+class IdPath(BaseModel):
+    id: str
+
+
+class PagenumPath(BaseModel):
+    pagenum: int
+
+
+class PagenumStrPath(BaseModel):
+    pagenum: str
+
+
+class UuidPath(BaseModel):
+    uuid: str
+
+
+class EntityTypePath(BaseModel):
+    entity_type: str
+
+
+class TargetDatetimePath(BaseModel):
+    target_datetime: str
+
+
+class EntityTypePagenumPath(BaseModel):
+    entity_type: str
+    pagenum: str
+
+
+class EntityIdActivityStreamPagenumPath(BaseModel):
+    entity_id: str
+    pagenum: str
+
+
+# OpenAPI decorator kwargs that should be stripped before passing to Flask's add_url_rule
+_OPENAPI_KWARGS = frozenset(
+    [
+        "tags",
+        "summary",
+        "responses",
+        "description",
+        "security",
+        "deprecated",
+        "external_docs",
+        "servers",
+        "operation_id",
+        "openapi_extensions",
+        "path",
+    ]
+)
+
+
+def _strip_openapi_kwargs(api):
+    """Wrap a blueprint's add_url_rule to strip Flask-OpenAPI3 decorator kwargs.
+
+    Flask-OpenAPI3 passes decorator metadata (tags, summary, responses, etc.) through
+    the decorator chain down to Flask's add_url_rule(). Those kwargs are not recognized
+    by Flask's Rule class and cause TypeError. This wrapper intercepts the call and
+    removes them before delegating to the original method.
+
+    Usage::
+
+        from flask_openapi3 import APIBlueprint
+        from flaskapp.openapi_models import _strip_openapi_kwargs
+
+        bp = APIBlueprint("mybp", __name__)
+        _strip_openapi_kwargs(bp)
+
+    After calling this, all route decorators on *bp* that use Flask-OpenAPI3 metadata
+    will work correctly because the OpenAPI kwargs are stripped before reaching Flask.
+    """
+    _original = api.add_url_rule
+
+    def _wrapped(*args, **kwargs):
+        for key in _OPENAPI_KWARGS:
+            kwargs.pop(key, None)
+        _original(*args, **kwargs)
+
+    api.add_url_rule = _wrapped

--- a/source/web-service/flaskapp/openapi_models.py
+++ b/source/web-service/flaskapp/openapi_models.py
@@ -50,6 +50,12 @@ class EntityBody(BaseModel):
     model_config = ConfigDict(extra="allow", populate_by_name=True)
 
 
+# Body payloads
+class PlainBody(BaseModel):
+    type: str = Field(..., description="Entity Type")
+    model_config = ConfigDict(extra="allow")
+
+
 JSONL_examples = {
     "Single record ingest": {
         "summary": "Example of how to ingest a single record. Add the whole document, with a newline",

--- a/source/web-service/flaskapp/openapi_models.py
+++ b/source/web-service/flaskapp/openapi_models.py
@@ -7,7 +7,7 @@ Each model defines a single path parameter matching a Flask URL rule converter
 (e.g. ``<path:entity_id>`` -> ``entity_id: str``, ``<int:pagenum>`` -> ``pagenum: int``).
 """
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ConfigDict, RootModel
 
 # from uuid import UUID
 from typing import Optional
@@ -37,7 +37,91 @@ from typing import Optional
 #     )
 
 
-# 1. Base Models with validation constraints applied via Field
+# Body payloads
+class EntityBody(BaseModel):
+    # This dictates to flask-openapi3-swagger that 'id' is required
+    id: Optional[str] = Field(default=None, description="Standard unique identifier")
+    at_id: Optional[str] = Field(
+        default=None, alias="@id", description="Alternative semantic identifier"
+    )
+    type: str = Field(..., description="Entity Type")
+
+    # Correct Pydantic v2 configuration for version 4.x+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+
+JSONL_examples = {
+    "Single record ingest": {
+        "summary": "Example of how to ingest a single record. Add the whole document, with a newline",
+        "value": '{"id": "---relative-identifier---", "type": "....", "etc": {...}, ... }\n',
+    },
+    "Multiple record ingest": {
+        "summary": "Multiple records. Split their JSON-encoded text with newlines",
+        "value": '{"id": "qfewf", "... }\n{"id": "qfewf2", "... }\n{"id": "qfewf3", "... }\n',
+    },
+    "Refresh a record": {
+        "summary": "Example of how to reload a single record into the graphstore (requires RDF processing) and LDP container index (if LDP_BACKEND is on)",
+        "value": '{"id": "---relative-identifier---", "_refresh": true}\n',
+    },
+    "Delete record(s)": {
+        "summary": "Example of how to delete a record.",
+        "value": '{"id": "...", "_delete": "true"}\n',
+    },
+}
+
+
+# Shared schema component to avoid writing the example each time
+class JSONLSchema(RootModel[str]):
+    root: str = Field(
+        description="Newline-delimited JSON records. One JSON object per line.",
+        examples=JSONL_examples,
+    )
+
+
+# Define multiple content types inside the 'content' object
+# eg @api.post('/upload-jsonl', extra_body=JSONLBody)
+JSONLBody = {
+    "description": "Upload structural records via raw text JSONL stream.",
+    "required": True,
+    "content": {
+        "text/plain": {  # To allow the swagger UI to work properly
+            "schema": {
+                "type": "string",
+            },
+            "examples": JSONL_examples,
+        },
+        "application/x-ndjson": {
+            "schema": {
+                "type": "string",
+            },
+            "examples": JSONL_examples,
+        },
+        "text/jsonl": {
+            "schema": {
+                "type": "string",
+            },
+            "examples": JSONL_examples,
+        },  # secondary allowed content-type
+        "application/json": {
+            "schema": {
+                "type": "string",
+            },
+            "examples": JSONL_examples,
+        },  # Fallback type
+    },
+}
+
+
+def patch_ingest_route(app, ns=None):
+    route_path = "/ingest"
+    if ns and ns != "/":
+        route_path = f"/{ns}/ingest"
+
+    if route_path in app.api_doc["paths"]:
+        app.api_doc["paths"][route_path]["post"]["requestBody"] = JSONLBody
+
+
+# Base Models with validation constraints applied via Field
 class EntityIdPath(BaseModel):
     entity_id: str = Field(
         ...,
@@ -64,27 +148,19 @@ class EntityTypePath(BaseModel):
 
 
 class TargetDatetimePath(BaseModel):
-    # If the endpoint expects an ISO string, using native datetime parses it
-    # correctly. If it must remain a raw string, use str with a datetime format description.
     target_datetime: str = Field(
-        ..., description="The target timestamp (ISO 8601 format)."
-    )
-
-
-class OptionalTargetDatetimePath(BaseModel):
-    target_datetime: Optional[str] = Field(
-        ..., description="The target timestamp (ISO 8601 format)."
+        ..., description="The target date time (11/10/2025, May 10th 2026, etc)."
     )
 
 
 class OptionalTargetDatetimeQuery(BaseModel):
     datetime: Optional[str] = Field(
         ...,
-        description="The target timestamp (ISO 8601 format) from a '?datetime=' parameter",
+        description="The target date time (11/10/2025, May 10th 2026, etc) from a '?datetime=' parameter",
     )
 
 
-# 2. Composite Models combining the validated parameters
+# Composite Models combining the validated parameters
 class EntityTypePagenumPath(BaseModel):
     entity_type: str = Field(
         ..., max_length=200, description="The type designation string of the entity."

--- a/source/web-service/flaskapp/openapi_models.py
+++ b/source/web-service/flaskapp/openapi_models.py
@@ -166,6 +166,13 @@ class OptionalTargetDatetimeQuery(BaseModel):
     )
 
 
+class OptionalSlugQuery(BaseModel):
+    slug: Optional[str] = Field(
+        default=None,
+        description="The slug you intend this item to get when it is uploaded",
+    )
+
+
 # Composite Models combining the validated parameters
 class EntityTypePagenumPath(BaseModel):
     entity_type: str = Field(

--- a/source/web-service/flaskapp/openapi_models.py
+++ b/source/web-service/flaskapp/openapi_models.py
@@ -44,13 +44,6 @@ class EntityIdPath(BaseModel):
     )
 
 
-class IdPath(BaseModel):
-    id: str = Field(
-        ...,
-        description="The relative identifier for a JSON object held in the LOD Gateway.",
-    )
-
-
 class PagenumPath(BaseModel):
     pagenum: int = Field(
         ..., ge=1, description="The page number. Starts at 1 with no upper bound."

--- a/source/web-service/flaskapp/openapi_models.py
+++ b/source/web-service/flaskapp/openapi_models.py
@@ -11,7 +11,6 @@ from pydantic import BaseModel, Field
 from uuid import UUID
 from typing import Optional
 
-
 # Example of a query model for GET parameters:
 # class EntityFiltersQuery(BaseModel):
 #     # Optional parameter with a default fallback value

--- a/source/web-service/flaskapp/openapi_models.py
+++ b/source/web-service/flaskapp/openapi_models.py
@@ -8,7 +8,8 @@ Each model defines a single path parameter matching a Flask URL rule converter
 """
 
 from pydantic import BaseModel, Field
-from uuid import UUID
+
+# from uuid import UUID
 from typing import Optional
 
 # Example of a query model for GET parameters:
@@ -52,7 +53,8 @@ class PagenumPath(BaseModel):
 
 class UuidPath(BaseModel):
     # Using Pydantic's native UUID type auto-validates format and updates Swagger UI
-    uuid: UUID = Field(..., description="A valid Universally Unique Identifier (UUID).")
+    # UUID is a little too narrow for this
+    uuid: str = Field(..., description="A valid Universally Unique Identifier (UUID).")
 
 
 class EntityTypePath(BaseModel):

--- a/source/web-service/flaskapp/routes/activity.py
+++ b/source/web-service/flaskapp/routes/activity.py
@@ -1,7 +1,7 @@
 import math
 
 from flask_openapi3 import APIBlueprint
-from flask import current_app, abort, request, redirect, jsonify, url_for
+from flask import current_app, abort, redirect, jsonify, url_for
 from sqlalchemy.orm import joinedload
 from sqlalchemy.sql.functions import coalesce, max
 from sqlalchemy import func
@@ -21,7 +21,8 @@ from flaskapp.errors import (
 )
 from flaskapp.openapi import activity_tag
 from flaskapp.openapi_models import (
-    TargetDatetimePath,
+    OptionalTargetDatetimePath,
+    OptionalTargetDatetimeQuery,
     PagenumPath,
     UuidPath,
     _strip_openapi_kwargs,
@@ -43,9 +44,15 @@ _strip_openapi_kwargs(activity)
     },
 )
 @activity.get("/activity-stream/skip-to-datetime/<string:target_datetime>")
-def redirect_to_page_using_datetime(target_datetime=None):
-    if "datetime" in request.args:
-        target_datetime = request.args["datetime"]
+def redirect_to_page_using_datetime(
+    path: OptionalTargetDatetimePath, query: OptionalTargetDatetimeQuery
+):
+    target_datetime = None
+
+    if path and path.target_datetime is not None:
+        target_datetime = path.target_datetime
+    elif query and query.datetime is not None:
+        target_datetime = query.datetime
 
     if not target_datetime:
         # response - bad request
@@ -145,7 +152,7 @@ def activity_stream_collection():
 
 
 # Abort if 'pagenum' is not integer
-@activity.get("/activity-stream/page/<string:pagenum>")
+@activity.get("/activity-stream/page/<int:pagenum>")
 def activity_stream_wrong_page_format(pagenum):
     response = construct_error_response(status_pagenum_not_integer)
     return abort(response)
@@ -155,14 +162,13 @@ def activity_stream_wrong_page_format(pagenum):
     "/activity-stream/page/<int:pagenum>",
     tags=[activity_tag],
     summary="Activity Stream page",
-    path=PagenumPath,
     responses={
         200: {"description": "Paginated activity items"},
         404: {"description": "Page out of bounds"},
     },
 )
 @activity.get("/activity-stream/page/<int:pagenum>")
-def activity_stream_page(pagenum):
+def activity_stream_page(path: PagenumPath):
     """Generate an OrderedCollectionPage of Activity Stream items.
 
     Args:
@@ -171,6 +177,13 @@ def activity_stream_page(pagenum):
     Returns:
         TYPE: Response: a JSON-encoded OrderedCollectionPage
     """
+
+    pagenum = None
+    if path and path.pagenum:
+        pagenum = path.pagenum
+
+    if not pagenum:
+        pagenum = 1
 
     limit = current_app.config["ITEMS_PER_PAGE"]
     offset = (pagenum - 1) * limit
@@ -206,7 +219,6 @@ def activity_stream_page(pagenum):
         .filter(Activity.id > offset, Activity.id <= offset + limit)
         .order_by("id")
     ):
-
         items = [generate_item(a) for a in activities]
         data["orderedItems"] = items
     else:
@@ -219,14 +231,13 @@ def activity_stream_page(pagenum):
     "/activity-stream/<string:uuid>",
     tags=[activity_tag],
     summary="Activity Stream item",
-    path=UuidPath,
     responses={
         200: {"description": "Activity item"},
         404: {"description": "Not found"},
     },
 )
 @activity.get("/activity-stream/<string:uuid>")
-def activity_stream_item(uuid):
+def activity_stream_item(path: UuidPath):
     """Generate an ActivityStreams Create Response
 
     Args:
@@ -238,7 +249,7 @@ def activity_stream_item(uuid):
 
     activity = (
         Activity.query.options(joinedload(Activity.record, innerjoin=True))
-        .filter(Activity.uuid == uuid)
+        .filter(Activity.uuid == path.uuid)
         .one_or_none()
     )
 

--- a/source/web-service/flaskapp/routes/activity.py
+++ b/source/web-service/flaskapp/routes/activity.py
@@ -151,13 +151,6 @@ def activity_stream_collection():
     return current_app.make_response(data)
 
 
-# Abort if 'pagenum' is not integer
-@activity.get("/activity-stream/page/<int:pagenum>")
-def activity_stream_wrong_page_format(pagenum):
-    response = construct_error_response(status_pagenum_not_integer)
-    return abort(response)
-
-
 @activity.get(
     "/activity-stream/page/<int:pagenum>",
     tags=[activity_tag],

--- a/source/web-service/flaskapp/routes/activity.py
+++ b/source/web-service/flaskapp/routes/activity.py
@@ -20,36 +20,16 @@ from flaskapp.errors import (
     status_page_not_found,
 )
 from flaskapp.openapi import activity_tag
+from flaskapp.openapi_models import (
+    TargetDatetimePath,
+    PagenumPath,
+    UuidPath,
+    _strip_openapi_kwargs,
+)
 
 # Create a new "activity" route blueprint
 activity = APIBlueprint("activity", __name__)
-
-_OPENAPI_KWARGS = frozenset(
-    [
-        "tags",
-        "summary",
-        "responses",
-        "description",
-        "security",
-        "deprecated",
-        "external_docs",
-        "servers",
-        "operation_id",
-        "openapi_extensions",
-    ]
-)
-
-
-_original_activity_add_url_rule = activity.add_url_rule
-
-
-def _activity_add_url_rule(*args, **kwargs):
-    for key in _OPENAPI_KWARGS:
-        kwargs.pop(key, None)
-    _original_activity_add_url_rule(*args, **kwargs)
-
-
-activity.add_url_rule = _activity_add_url_rule
+_strip_openapi_kwargs(activity)
 
 
 @activity.get(
@@ -175,6 +155,7 @@ def activity_stream_wrong_page_format(pagenum):
     "/activity-stream/page/<int:pagenum>",
     tags=[activity_tag],
     summary="Activity Stream page",
+    path=PagenumPath,
     responses={
         200: {"description": "Paginated activity items"},
         404: {"description": "Page out of bounds"},
@@ -238,6 +219,7 @@ def activity_stream_page(pagenum):
     "/activity-stream/<string:uuid>",
     tags=[activity_tag],
     summary="Activity Stream item",
+    path=UuidPath,
     responses={
         200: {"description": "Activity item"},
         404: {"description": "Not found"},

--- a/source/web-service/flaskapp/routes/activity.py
+++ b/source/web-service/flaskapp/routes/activity.py
@@ -21,7 +21,7 @@ from flaskapp.errors import (
 )
 from flaskapp.openapi import activity_tag
 from flaskapp.openapi_models import (
-    OptionalTargetDatetimePath,
+    TargetDatetimePath,
     OptionalTargetDatetimeQuery,
     PagenumPath,
     UuidPath,
@@ -33,6 +33,7 @@ activity = APIBlueprint("activity", __name__)
 _strip_openapi_kwargs(activity)
 
 
+# GET param method:
 @activity.get(
     "/activity-stream/skip-to-datetime",
     tags=[activity_tag],
@@ -43,17 +44,25 @@ _strip_openapi_kwargs(activity)
         404: {"description": "No activity found for date"},
     },
 )
-@activity.get("/activity-stream/skip-to-datetime/<string:target_datetime>")
-def redirect_to_page_using_datetime(
-    path: OptionalTargetDatetimePath, query: OptionalTargetDatetimeQuery
-):
-    target_datetime = None
+def get_param_redirect_to_page(query: OptionalTargetDatetimeQuery):
+    return _redirect_to_page_using_datetime(query.datetime)
 
-    if path and path.target_datetime is not None:
-        target_datetime = path.target_datetime
-    elif query and query.datetime is not None:
-        target_datetime = query.datetime
 
+@activity.get(
+    "/activity-stream/skip-to-datetime/<string:target_datetime>",
+    tags=[activity_tag],
+    summary="Skip to activity page by datetime",
+    responses={
+        200: {"description": "Redirect or results"},
+        400: {"description": "Bad datetime"},
+        404: {"description": "No activity found for date"},
+    },
+)
+def path_datetime_redirect_to_page(path: TargetDatetimePath):
+    return _redirect_to_page_using_datetime(path.target_datetime)
+
+
+def _redirect_to_page_using_datetime(target_datetime=None):
     if not target_datetime:
         # response - bad request
         return (

--- a/source/web-service/flaskapp/routes/activity.py
+++ b/source/web-service/flaskapp/routes/activity.py
@@ -1,6 +1,7 @@
 import math
 
-from flask import Blueprint, current_app, abort, request, redirect, jsonify, url_for
+from flask_openapi3 import APIBlueprint
+from flask import current_app, abort, request, redirect, jsonify, url_for
 from sqlalchemy.orm import joinedload
 from sqlalchemy.sql.functions import coalesce, max
 from sqlalchemy import func
@@ -18,13 +19,50 @@ from flaskapp.errors import (
     status_pagenum_not_integer,
     status_page_not_found,
 )
+from flaskapp.openapi import activity_tag
 
 # Create a new "activity" route blueprint
-activity = Blueprint("activity", __name__)
+activity = APIBlueprint("activity", __name__)
+
+_OPENAPI_KWARGS = frozenset(
+    [
+        "tags",
+        "summary",
+        "responses",
+        "description",
+        "security",
+        "deprecated",
+        "external_docs",
+        "servers",
+        "operation_id",
+        "openapi_extensions",
+    ]
+)
 
 
-@activity.route("/activity-stream/skip-to-datetime")
-@activity.route("/activity-stream/skip-to-datetime/<string:target_datetime>")
+_original_activity_add_url_rule = activity.add_url_rule
+
+
+def _activity_add_url_rule(*args, **kwargs):
+    for key in _OPENAPI_KWARGS:
+        kwargs.pop(key, None)
+    _original_activity_add_url_rule(*args, **kwargs)
+
+
+activity.add_url_rule = _activity_add_url_rule
+
+
+@activity.get(
+    "/activity-stream/skip-to-datetime",
+    tags=[activity_tag],
+    summary="Skip to activity page by datetime",
+    responses={
+        200: {"description": "Redirect or results"},
+        400: {"description": "Bad datetime"},
+        404: {"description": "No activity found for date"},
+    },
+)
+@activity.get("/activity-stream/skip-to-datetime/<string:target_datetime>")
 def redirect_to_page_using_datetime(target_datetime=None):
     if "datetime" in request.args:
         target_datetime = request.args["datetime"]
@@ -86,8 +124,13 @@ def redirect_to_page_using_datetime(target_datetime=None):
         )
 
 
-@activity.route("/activity-stream")
-@activity.route("/activity-stream/")
+@activity.get(
+    "/activity-stream",
+    tags=[activity_tag],
+    summary="Activity Stream root",
+    responses={200: {"description": "Activity Stream collection"}},
+)
+@activity.get("/activity-stream/")
 def activity_stream_collection():
     """Generate the root OrderedCollection for the stream
 
@@ -122,13 +165,22 @@ def activity_stream_collection():
 
 
 # Abort if 'pagenum' is not integer
-@activity.route("/activity-stream/page/<string:pagenum>")
+@activity.get("/activity-stream/page/<string:pagenum>")
 def activity_stream_wrong_page_format(pagenum):
     response = construct_error_response(status_pagenum_not_integer)
     return abort(response)
 
 
-@activity.route("/activity-stream/page/<int:pagenum>")
+@activity.get(
+    "/activity-stream/page/<int:pagenum>",
+    tags=[activity_tag],
+    summary="Activity Stream page",
+    responses={
+        200: {"description": "Paginated activity items"},
+        404: {"description": "Page out of bounds"},
+    },
+)
+@activity.get("/activity-stream/page/<int:pagenum>")
 def activity_stream_page(pagenum):
     """Generate an OrderedCollectionPage of Activity Stream items.
 
@@ -182,7 +234,16 @@ def activity_stream_page(pagenum):
     return current_app.make_response(data)
 
 
-@activity.route("/activity-stream/<string:uuid>")
+@activity.get(
+    "/activity-stream/<string:uuid>",
+    tags=[activity_tag],
+    summary="Activity Stream item",
+    responses={
+        200: {"description": "Activity item"},
+        404: {"description": "Not found"},
+    },
+)
+@activity.get("/activity-stream/<string:uuid>")
 def activity_stream_item(uuid):
     """Generate an ActivityStreams Create Response
 

--- a/source/web-service/flaskapp/routes/activity_entity.py
+++ b/source/web-service/flaskapp/routes/activity_entity.py
@@ -1,6 +1,7 @@
 import math
 
-from flask import Blueprint, current_app, abort
+from flask_openapi3 import APIBlueprint
+from flask import current_app, abort
 from sqlalchemy import func
 
 from flaskapp.models import db
@@ -12,9 +13,37 @@ from flaskapp.errors import (
     status_record_not_found,
     status_page_not_found,
 )
+from flaskapp.openapi import activity_tag
 
 # Create a new "activity" route blueprint
-activity_entity = Blueprint("activity_entity", __name__)
+activity_entity = APIBlueprint("activity_entity", __name__)
+
+_OPENAPI_KWARGS = frozenset(
+    [
+        "tags",
+        "summary",
+        "responses",
+        "description",
+        "security",
+        "deprecated",
+        "external_docs",
+        "servers",
+        "operation_id",
+        "openapi_extensions",
+    ]
+)
+
+
+_original_activity_entity_add_url_rule = activity_entity.add_url_rule
+
+
+def _activity_entity_add_url_rule(*args, **kwargs):
+    for key in _OPENAPI_KWARGS:
+        kwargs.pop(key, None)
+    _original_activity_entity_add_url_rule(*args, **kwargs)
+
+
+activity_entity.add_url_rule = _activity_entity_add_url_rule
 
 # Make the list of entity types global to populate it only once
 lod_entity_types = []
@@ -23,7 +52,16 @@ lod_entity_types = []
 ### Activity Stream Entity Routes ###
 
 
-@activity_entity.route("/activity-stream/type/<string:entity_type>")
+@activity_entity.get(
+    "/activity-stream/type/<string:entity_type>",
+    tags=[activity_tag],
+    summary="Activity Stream by entity type",
+    responses={
+        200: {"description": "Filtered activity collection"},
+        404: {"description": "Entity type not found"},
+    },
+)
+@activity_entity.get("/activity-stream/type/<string:entity_type>")
 def activity_stream_entity_collection(entity_type):
     entity_type = entity_type.lower()
     global lod_entity_types
@@ -37,7 +75,16 @@ def activity_stream_entity_collection(entity_type):
     return current_app.make_response(data)
 
 
-@activity_entity.route(
+@activity_entity.get(
+    "/activity-stream/type/<string:entity_type>/page/<string:pagenum>",
+    tags=[activity_tag],
+    summary="Activity Stream by type, paginated",
+    responses={
+        200: {"description": "Paginated activity items"},
+        404: {"description": "Not found"},
+    },
+)
+@activity_entity.get(
     "/activity-stream/type/<string:entity_type>/page/<string:pagenum>"
 )
 def activity_stream_entity_page(entity_type, pagenum):

--- a/source/web-service/flaskapp/routes/activity_entity.py
+++ b/source/web-service/flaskapp/routes/activity_entity.py
@@ -35,14 +35,14 @@ lod_entity_types = []
     "/activity-stream/type/<string:entity_type>",
     tags=[activity_tag],
     summary="Activity Stream by entity type",
-    path=EntityTypePath,
     responses={
         200: {"description": "Filtered activity collection"},
         404: {"description": "Entity type not found"},
     },
 )
 @activity_entity.get("/activity-stream/type/<string:entity_type>")
-def activity_stream_entity_collection(entity_type):
+def activity_stream_entity_collection(path: EntityTypePath):
+    entity_type = path.entity_type
     entity_type = entity_type.lower()
     global lod_entity_types
     if len(lod_entity_types) == 0:
@@ -66,9 +66,9 @@ def activity_stream_entity_collection(entity_type):
     },
 )
 @activity_entity.get("/activity-stream/type/<string:entity_type>/page/<string:pagenum>")
-def activity_stream_entity_page(entity_type, pagenum):
-    entity_type = entity_type.lower()
-    data = create_page_data(pagenum, entity_type)
+def activity_stream_entity_page(path: EntityTypePagenumPath):
+    entity_type = path.entity_type.lower()
+    data = create_page_data(path.pagenum, entity_type)
     return current_app.make_response(data)
 
 

--- a/source/web-service/flaskapp/routes/activity_entity.py
+++ b/source/web-service/flaskapp/routes/activity_entity.py
@@ -14,36 +14,15 @@ from flaskapp.errors import (
     status_page_not_found,
 )
 from flaskapp.openapi import activity_tag
+from flaskapp.openapi_models import (
+    EntityTypePath,
+    EntityTypePagenumPath,
+    _strip_openapi_kwargs,
+)
 
 # Create a new "activity" route blueprint
 activity_entity = APIBlueprint("activity_entity", __name__)
-
-_OPENAPI_KWARGS = frozenset(
-    [
-        "tags",
-        "summary",
-        "responses",
-        "description",
-        "security",
-        "deprecated",
-        "external_docs",
-        "servers",
-        "operation_id",
-        "openapi_extensions",
-    ]
-)
-
-
-_original_activity_entity_add_url_rule = activity_entity.add_url_rule
-
-
-def _activity_entity_add_url_rule(*args, **kwargs):
-    for key in _OPENAPI_KWARGS:
-        kwargs.pop(key, None)
-    _original_activity_entity_add_url_rule(*args, **kwargs)
-
-
-activity_entity.add_url_rule = _activity_entity_add_url_rule
+_strip_openapi_kwargs(activity_entity)
 
 # Make the list of entity types global to populate it only once
 lod_entity_types = []
@@ -56,6 +35,7 @@ lod_entity_types = []
     "/activity-stream/type/<string:entity_type>",
     tags=[activity_tag],
     summary="Activity Stream by entity type",
+    path=EntityTypePath,
     responses={
         200: {"description": "Filtered activity collection"},
         404: {"description": "Entity type not found"},
@@ -79,14 +59,13 @@ def activity_stream_entity_collection(entity_type):
     "/activity-stream/type/<string:entity_type>/page/<string:pagenum>",
     tags=[activity_tag],
     summary="Activity Stream by type, paginated",
+    path=EntityTypePagenumPath,
     responses={
         200: {"description": "Paginated activity items"},
         404: {"description": "Not found"},
     },
 )
-@activity_entity.get(
-    "/activity-stream/type/<string:entity_type>/page/<string:pagenum>"
-)
+@activity_entity.get("/activity-stream/type/<string:entity_type>/page/<string:pagenum>")
 def activity_stream_entity_page(entity_type, pagenum):
     entity_type = entity_type.lower()
     data = create_page_data(pagenum, entity_type)

--- a/source/web-service/flaskapp/routes/activity_entity.py
+++ b/source/web-service/flaskapp/routes/activity_entity.py
@@ -56,7 +56,7 @@ def activity_stream_entity_collection(entity_type):
 
 
 @activity_entity.get(
-    "/activity-stream/type/<string:entity_type>/page/<string:pagenum>",
+    "/activity-stream/type/<string:entity_type>/page/<int:pagenum>",
     tags=[activity_tag],
     summary="Activity Stream by type, paginated",
     path=EntityTypePagenumPath,

--- a/source/web-service/flaskapp/routes/health.py
+++ b/source/web-service/flaskapp/routes/health.py
@@ -1,4 +1,5 @@
-from flask import Blueprint, current_app, abort, request
+from flask_openapi3 import APIBlueprint
+from flask import current_app, abort, request
 
 from flaskapp.models import db
 from flaskapp.routes import ingest
@@ -12,13 +13,49 @@ from flaskapp.errors import (
 from sqlalchemy import text
 
 from flaskapp.utilities import authenticate_bearer
+from flaskapp.openapi import health_tag
 
 # Create a new "health_check" route blueprint
-health = Blueprint("health", __name__)
+health = APIBlueprint("health", __name__)
+
+_OPENAPI_KWARGS = frozenset(
+    [
+        "tags",
+        "summary",
+        "responses",
+        "description",
+        "security",
+        "deprecated",
+        "external_docs",
+        "servers",
+        "operation_id",
+        "openapi_extensions",
+    ]
+)
+
+
+_original_health_add_url_rule = health.add_url_rule
+
+
+def _health_add_url_rule(*args, **kwargs):
+    for key in _OPENAPI_KWARGS:
+        kwargs.pop(key, None)
+    _original_health_add_url_rule(*args, **kwargs)
+
+
+health.add_url_rule = _health_add_url_rule
 
 
 # Checks DB Connectivity ONLY
-@health.route("/health", methods=["GET"])
+@health.get(
+    "/health",
+    tags=[health_tag],
+    summary="Health check",
+    responses={
+        200: {"description": "OK"},
+        503: {"description": "Database unavailable"},
+    },
+)
 def healthcheck_get():
     if health_db():
         return "OK"
@@ -28,7 +65,18 @@ def healthcheck_get():
 
 
 # Checks DB Connectivity ONLY
-@health.route("/authhealth", methods=["GET"])
+@health.get(
+    "/authhealth",
+    tags=[health_tag],
+    summary="Authenticated health check",
+    description="Same as /health but requires a valid bearer token.",
+    security=[{"bearerAuth": []}],
+    responses={
+        200: {"description": "OK"},
+        401: {"description": "Unauthorized"},
+        503: {"description": "Database unavailable"},
+    },
+)
 def authd_healthcheck_get():
     # same as the normal healthcheck, but requires authentication. This will be a cheap
     # way for a client to make sure that its authentication token is correct.
@@ -47,7 +95,16 @@ def authd_healthcheck_get():
 
 
 # Checks DB Connectivity AND SPARQL endpoint status
-@health.route("/rdfhealth", methods=["GET"])
+@health.get(
+    "/rdfhealth",
+    tags=[health_tag],
+    summary="RDF health check",
+    description="Checks database connectivity AND (when RDF processing is enabled) the SPARQL endpoint status.",
+    responses={
+        200: {"description": "OK"},
+        503: {"description": "Database or SPARQL endpoint unavailable"},
+    },
+)
 def rdf_healthcheck_get():
     # same as the normal healthcheck, but also checks the RDF SPARQL endpoint access
 

--- a/source/web-service/flaskapp/routes/home_page.py
+++ b/source/web-service/flaskapp/routes/home_page.py
@@ -1,5 +1,5 @@
+from flask_openapi3 import APIBlueprint
 from flask import (
-    Blueprint,
     render_template,
     current_app,
     request,
@@ -25,13 +25,49 @@ from flaskapp.storage_utilities.container import (
 )
 from flaskapp.conneg import determine_requested_format_and_profile, reformat_rdf
 from flaskapp.utilities import wants_html
+from flaskapp.openapi import home_tag
 from flaskapp.errors import construct_error_response, status_container_not_found
 
 # Create home page
-home_page = Blueprint("home_page", __name__)
+home_page = APIBlueprint("home_page", __name__)
+
+_OPENAPI_KWARGS = frozenset(
+    [
+        "tags",
+        "summary",
+        "responses",
+        "description",
+        "security",
+        "deprecated",
+        "external_docs",
+        "servers",
+        "operation_id",
+        "openapi_extensions",
+    ]
+)
 
 
-@home_page.route("/", methods=["GET"])
+_original_home_page_add_url_rule = home_page.add_url_rule
+
+
+def _home_page_add_url_rule(*args, **kwargs):
+    for key in _OPENAPI_KWARGS:
+        kwargs.pop(key, None)
+    _original_home_page_add_url_rule(*args, **kwargs)
+
+
+home_page.add_url_rule = _home_page_add_url_rule
+
+
+@home_page.get(
+    "/",
+    tags=[home_tag],
+    summary="Root container / LDP container root",
+    responses={
+        200: {"description": "LDP container listing"},
+        303: {"description": "Redirect to dashboard"},
+    },
+)
 def root_container():
     if wants_html(request) or current_app.config["LDP_API"] is False:
         # Send them to the dashboard instead:
@@ -97,7 +133,14 @@ def root_container():
         )
 
 
-@home_page.route("/dashboard", methods=["GET"])
+@home_page.get(
+    "/dashboard",
+    tags=[home_tag],
+    summary="Dashboard",
+    responses={
+        200: {"description": "Dashboard data or HTML"},
+    },
+)
 def get_home_page():
     if not wants_html(request):
         return (

--- a/source/web-service/flaskapp/routes/home_page.py
+++ b/source/web-service/flaskapp/routes/home_page.py
@@ -26,37 +26,12 @@ from flaskapp.storage_utilities.container import (
 from flaskapp.conneg import determine_requested_format_and_profile, reformat_rdf
 from flaskapp.utilities import wants_html
 from flaskapp.openapi import home_tag
+from flaskapp.openapi_models import _strip_openapi_kwargs
 from flaskapp.errors import construct_error_response, status_container_not_found
 
 # Create home page
 home_page = APIBlueprint("home_page", __name__)
-
-_OPENAPI_KWARGS = frozenset(
-    [
-        "tags",
-        "summary",
-        "responses",
-        "description",
-        "security",
-        "deprecated",
-        "external_docs",
-        "servers",
-        "operation_id",
-        "openapi_extensions",
-    ]
-)
-
-
-_original_home_page_add_url_rule = home_page.add_url_rule
-
-
-def _home_page_add_url_rule(*args, **kwargs):
-    for key in _OPENAPI_KWARGS:
-        kwargs.pop(key, None)
-    _original_home_page_add_url_rule(*args, **kwargs)
-
-
-home_page.add_url_rule = _home_page_add_url_rule
+_strip_openapi_kwargs(home_page)
 
 
 @home_page.get(

--- a/source/web-service/flaskapp/routes/ingest.py
+++ b/source/web-service/flaskapp/routes/ingest.py
@@ -51,6 +51,8 @@ from flaskapp.utilities import (
 from flaskapp.base_graph_utils import base_graph_filter
 from flaskapp.openapi import ingest_tag
 
+# For path typing
+
 # Create a new "ingest" route blueprint
 ingest = APIBlueprint("ingest", __name__)
 
@@ -66,9 +68,9 @@ _OPENAPI_KWARGS = frozenset(
         "servers",
         "operation_id",
         "openapi_extensions",
+        "extra_body",
     ]
 )
-
 
 _original_ingest_add_url_rule = ingest.add_url_rule
 

--- a/source/web-service/flaskapp/routes/ingest.py
+++ b/source/web-service/flaskapp/routes/ingest.py
@@ -88,6 +88,7 @@ ingest.add_url_rule = _ingest_add_url_rule
     "/ingest",
     tags=[ingest_tag],
     summary="Ingest (GET — forbidden)",
+    description="The ingest endpoint only accepts POST requests. Use POST with a JSON-LD payload.",
     responses={405: {"description": "Method not allowed"}},
 )
 def ingest_get():
@@ -99,6 +100,8 @@ def ingest_get():
     "/ingest",
     tags=[ingest_tag],
     summary="Batch ingest records",
+    description="Batch ingest one or more JSON-LD records. Requires Bearer token authentication via `Authorization: Bearer <token>` header.\n\nAll records in a batch are processed atomically — a failure in any record rolls back the entire batch.",
+    security=[{"bearerAuth": []}],
     responses={
         200: {"description": "Ingestion results"},
         400: {"description": "Validation error"},

--- a/source/web-service/flaskapp/routes/ingest.py
+++ b/source/web-service/flaskapp/routes/ingest.py
@@ -8,7 +8,8 @@ from random import random
 
 import requests
 
-from flask import Blueprint, current_app, request, abort, jsonify
+from flask_openapi3 import APIBlueprint
+from flask import current_app, request, abort, jsonify
 from sqlalchemy import exc
 
 from flaskapp.models import db
@@ -48,20 +49,63 @@ from flaskapp.utilities import (
     authenticate_bearer,
 )
 from flaskapp.base_graph_utils import base_graph_filter
+from flaskapp.openapi import ingest_tag
 
 # Create a new "ingest" route blueprint
-ingest = Blueprint("ingest", __name__)
+ingest = APIBlueprint("ingest", __name__)
+
+_OPENAPI_KWARGS = frozenset(
+    [
+        "tags",
+        "summary",
+        "responses",
+        "description",
+        "security",
+        "deprecated",
+        "external_docs",
+        "servers",
+        "operation_id",
+        "openapi_extensions",
+    ]
+)
+
+
+_original_ingest_add_url_rule = ingest.add_url_rule
+
+
+def _ingest_add_url_rule(*args, **kwargs):
+    for key in _OPENAPI_KWARGS:
+        kwargs.pop(key, None)
+    _original_ingest_add_url_rule(*args, **kwargs)
+
+
+ingest.add_url_rule = _ingest_add_url_rule
 
 
 # ### ROUTES ###
 # 'GET' method is forbidden. Abort with 405
-@ingest.route("/ingest", methods=["GET"])
+@ingest.get(
+    "/ingest",
+    tags=[ingest_tag],
+    summary="Ingest (GET — forbidden)",
+    responses={405: {"description": "Method not allowed"}},
+)
 def ingest_get():
     response = construct_error_response(status_GET_not_allowed)
     return abort(response)
 
 
-@ingest.route("/ingest", methods=["POST"])
+@ingest.post(
+    "/ingest",
+    tags=[ingest_tag],
+    summary="Batch ingest records",
+    responses={
+        200: {"description": "Ingestion results"},
+        400: {"description": "Validation error"},
+        401: {"description": "Unauthorized"},
+        503: {"description": "Database error"},
+    },
+)
 def ingest_post():
     # Authentication. If fails, abort with 401
     status = authenticate_bearer(request, current_app)

--- a/source/web-service/flaskapp/routes/records.py
+++ b/source/web-service/flaskapp/routes/records.py
@@ -69,6 +69,7 @@ from flaskapp.openapi import records_tag, ldp_tag, timegate_tag, activity_tag
 from flaskapp.openapi_models import (
     EntityIdPath,
     EntityBody,
+    PlainBody,
     EntityIdActivityStreamPagenumPath,
     _strip_openapi_kwargs,
 )
@@ -356,7 +357,7 @@ def container_record(container_id, page=None):
     strict_slashes=False,
 )
 @records.post("/", defaults={"entity_id": "/"}, strict_slashes=False)
-def container_post_item(path: EntityIdPath, body: EntityBody):
+def container_post_item(path: EntityIdPath, body: PlainBody):
     # Could be a resource or a container being POSTed to a target URI which has to be an existing container
     # Behavior will be as LDP states:
     # - if the target is a Container, and the POSTed item is a valid Resource or Container:
@@ -404,7 +405,7 @@ def container_post_item(path: EntityIdPath, body: EntityBody):
             f'{current_app.config["idPrefix"]}/',
             container_breadcrumbs[-1].strip("/"),
             request,
-            EntityBody,
+            body,
         )
         current_app.logger.info(
             f"POSTed JSON parsed as JSON-LD and rebased to: {posted_representation.has_top_level_id()}"

--- a/source/web-service/flaskapp/routes/records.py
+++ b/source/web-service/flaskapp/routes/records.py
@@ -367,10 +367,12 @@ def container_record(container_id, page=None):
         401: {"description": "Unauthorized"},
         409: {"description": "Conflict"},
     },
+    strict_slashes=False
 )
 @records.post(
     "/",
     defaults={"entity_id": "/"},
+    strict_slashes=False
 )
 def container_post_item(entity_id):
     # Could be a resource or a container being POSTed to a target URI which has to be an existing container

--- a/source/web-service/flaskapp/routes/records.py
+++ b/source/web-service/flaskapp/routes/records.py
@@ -63,6 +63,12 @@ from flaskapp.errors import (
 from flaskapp.utilities import checksum_json, authenticate_bearer, squish_dict
 from flaskapp.base_graph_utils import get_url_prefixes_from_context
 from flaskapp.openapi import records_tag, ldp_tag, timegate_tag, activity_tag
+from flaskapp.openapi_models import (
+    EntityIdPath,
+    IdPath,
+    EntityIdActivityStreamPagenumPath,
+    _strip_openapi_kwargs,
+)
 
 # RDF format translations
 from flaskapp.graph_prefix_bindings import get_bound_graph, FORMATS
@@ -79,33 +85,7 @@ from pyld import jsonld
 
 # Create a new "records" route blueprint
 records = APIBlueprint("records", __name__)
-
-_OPENAPI_KWARGS = frozenset(
-    [
-        "tags",
-        "summary",
-        "responses",
-        "description",
-        "security",
-        "deprecated",
-        "external_docs",
-        "servers",
-        "operation_id",
-        "openapi_extensions",
-    ]
-)
-
-
-_original_records_add_url_rule = records.add_url_rule
-
-
-def _records_add_url_rule(*args, **kwargs):
-    for key in _OPENAPI_KWARGS:
-        kwargs.pop(key, None)
-    _original_records_add_url_rule(*args, **kwargs)
-
-
-records.add_url_rule = _records_add_url_rule
+_strip_openapi_kwargs(records)
 
 trueset = {"true", "t", "y"}
 
@@ -361,19 +341,16 @@ def container_record(container_id, page=None):
     "/<path:entity_id>/",
     tags=[ldp_tag, records_tag],
     summary="Create resource (LDP)",
+    path=EntityIdPath,
     responses={
         201: {"description": "Resource created"},
         400: {"description": "Bad request"},
         401: {"description": "Unauthorized"},
         409: {"description": "Conflict"},
     },
-    strict_slashes=False
+    strict_slashes=False,
 )
-@records.post(
-    "/",
-    defaults={"entity_id": "/"},
-    strict_slashes=False
-)
+@records.post("/", defaults={"entity_id": "/"}, strict_slashes=False)
 def container_post_item(entity_id):
     # Could be a resource or a container being POSTed to a target URI which has to be an existing container
     # Behavior will be as LDP states:
@@ -632,6 +609,7 @@ def container_post_item(entity_id):
     "/<path:entity_id>",
     tags=[records_tag],
     summary="Get record",
+    path=EntityIdPath,
     responses={
         200: {"description": "Record data in requested format"},
         304: {"description": "Not Modified (ETag match)"},
@@ -1124,6 +1102,7 @@ def entity_record(entity_id):
     "/<path:id>",
     tags=[records_tag],
     summary="Delete record",
+    path=IdPath,
     responses={
         200: {"description": "Deleted successfully"},
         401: {"description": "Unauthorized"},
@@ -1235,6 +1214,7 @@ def delete(id):
     "/-VERSION-/<path:entity_id>",
     tags=[timegate_tag, records_tag],
     summary="Get record version",
+    path=EntityIdPath,
     responses={
         200: {"description": "Version data"},
         304: {"description": "Not Modified"},
@@ -1440,6 +1420,7 @@ def entity_version(entity_id):
     "/-VERSION-/<path:entity_id>",
     tags=[timegate_tag],
     summary="Delete record version",
+    path=EntityIdPath,
     responses={
         200: {"description": "Version deleted"},
         404: {"description": "Not found"},
@@ -1485,6 +1466,7 @@ def delete_entity_version(entity_id):
     "/<path:entity_id>/activity-stream",
     tags=[activity_tag],
     summary="Record activity stream",
+    path=EntityIdPath,
     responses={
         200: {"description": "Activity stream"},
         404: {"description": "No activity stream for this record"},
@@ -1526,6 +1508,7 @@ def entity_record_activity_stream(entity_id):
     "/<path:entity_id>/activity-stream",
     tags=[activity_tag],
     summary="Truncate record activity stream",
+    path=EntityIdPath,
     responses={
         200: {"description": "Events removed"},
         400: {"description": "Bad request"},
@@ -1617,6 +1600,7 @@ def truncate_activity_stream_of_entity_id(entity_id):
     "/<path:entity_id>/activity-stream/page/<string:pagenum>",
     tags=[activity_tag],
     summary="Record activity stream page",
+    path=EntityIdActivityStreamPagenumPath,
     responses={
         200: {"description": "Paginated activity items"},
         404: {"description": "Page out of bounds"},

--- a/source/web-service/flaskapp/routes/records.py
+++ b/source/web-service/flaskapp/routes/records.py
@@ -346,6 +346,8 @@ def container_record(container_id, page=None):
     "/<path:entity_id>/",
     tags=[ldp_tag, records_tag],
     summary="Create resource (LDP)",
+    description="Create a new resource or container by POSTing to an LDP container. Requires Bearer token authentication.",
+    security=[{"bearerAuth": []}],
     responses={
         201: {"description": "Resource created"},
         400: {"description": "Bad request"},
@@ -1105,6 +1107,8 @@ def entity_record(path: EntityIdPath):
     "/<path:id>",
     tags=[records_tag],
     summary="Delete record",
+    description="Permanently delete a record by entity ID. Requires Bearer token authentication.",
+    security=[{"bearerAuth": []}],
     responses={
         200: {"description": "Deleted successfully"},
         401: {"description": "Unauthorized"},
@@ -1216,6 +1220,8 @@ def delete(path: IdPath):
     "/-VERSION-/<path:entity_id>",
     tags=[timegate_tag, records_tag],
     summary="Get record version",
+    description="Retrieve a previous version of a record. Authentication is required if the VERSION_AUTH environment variable is set to true (default: true).",
+    security=[{"bearerAuth": []}, {}],
     responses={
         200: {"description": "Version data"},
         304: {"description": "Not Modified"},
@@ -1423,6 +1429,8 @@ def entity_version(path: EntityIdPath):
     "/-VERSION-/<path:entity_id>",
     tags=[timegate_tag],
     summary="Delete record version",
+    description="Delete a specific previous version of a record. Requires Bearer token authentication.",
+    security=[{"bearerAuth": []}],
     responses={
         200: {"description": "Version deleted"},
         404: {"description": "Not found"},
@@ -1511,6 +1519,8 @@ def entity_record_activity_stream(path: EntityIdPath):
     "/<path:entity_id>/activity-stream",
     tags=[activity_tag],
     summary="Truncate record activity stream",
+    description="Truncate the activity stream for a record, keeping only the N most recent events specified by the `keep` query parameter. Requires Bearer token authentication.",
+    security=[{"bearerAuth": []}],
     responses={
         200: {"description": "Events removed"},
         400: {"description": "Bad request"},

--- a/source/web-service/flaskapp/routes/records.py
+++ b/source/web-service/flaskapp/routes/records.py
@@ -68,7 +68,7 @@ from flaskapp.openapi import records_tag, ldp_tag, timegate_tag, activity_tag
 # For path typing
 from flaskapp.openapi_models import (
     EntityIdPath,
-    EntityBody,
+    ContainerIdPath,
     PlainBody,
     OptionalSlugQuery,
     EntityIdActivityStreamPagenumPath,
@@ -344,7 +344,7 @@ def container_record(container_id, page=None):
 
 
 @records.post(
-    "/<path:entity_id>/",
+    "/<path:container_id>/",
     tags=[ldp_tag, records_tag],
     summary="Create resource (LDP)",
     description="Create a new resource or container by POSTing to an LDP container. Requires Bearer token authentication.",
@@ -357,9 +357,9 @@ def container_record(container_id, page=None):
     },
     strict_slashes=False,
 )
-@records.post("/", defaults={"entity_id": "/"}, strict_slashes=False)
+@records.post("/", defaults={"container_id": "/"}, strict_slashes=False)
 def container_post_item(
-    path: EntityIdPath, body: PlainBody, query: OptionalSlugQuery = None
+    path: ContainerIdPath, body: PlainBody, query: OptionalSlugQuery = None
 ):
     # Could be a resource or a container being POSTed to a target URI which has to be an existing container
     # Behavior will be as LDP states:
@@ -397,10 +397,10 @@ def container_post_item(
         "Authentication checked - POST LDP resource request allowed."
     )
 
-    # Get the implied container-hierarchy from the entity_id:
+    # Get the implied container-hierarchy from the container_id:
     # eg "/object/1234" --> ["/", "/object/", "/object/1234"]
-    # Will always contain "/" as first item, unless the entity_id is "/"
-    container_breadcrumbs = segment_entity_id(path.entity_id)
+    # Will always contain "/" as first item, unless the container_id is "/"
+    container_breadcrumbs = segment_entity_id(path.container_id)
 
     # Valid JSON-LD? Fail if not with a HTTP 422 Wrong Syntax
     try:
@@ -439,11 +439,11 @@ def container_post_item(
 
     # Is there a record here?
     current_app.logger.debug(
-        f"Looking up resource {path.entity_id} in case it is a record not a container"
+        f"Looking up resource {path.container_id} in case it is a record not a container"
     )
     record = (
         db.session.query(Record)
-        .filter(Record.entity_id == path.entity_id)
+        .filter(Record.entity_id == path.container_id)
         .options(defer(Record.data))
         .limit(1)
         .one_or_none()
@@ -610,7 +610,7 @@ def container_post_item(
             status_nt(
                 404,
                 "No Resource Found",
-                f"Must POST a resource to a valid ldp:BasicContainer. {path.entity_id} is not a container",
+                f"Must POST a resource to a valid ldp:BasicContainer. {path.container_id} is not a container",
             )
         )
         abort(response)

--- a/source/web-service/flaskapp/routes/records.py
+++ b/source/web-service/flaskapp/routes/records.py
@@ -1,4 +1,5 @@
 import click
+from typing import Optional
 import math
 import json
 
@@ -63,12 +64,7 @@ from flaskapp.errors import (
 from flaskapp.utilities import checksum_json, authenticate_bearer, squish_dict
 from flaskapp.base_graph_utils import get_url_prefixes_from_context
 from flaskapp.openapi import records_tag, ldp_tag, timegate_tag, activity_tag
-from flaskapp.openapi_models import (
-    EntityIdPath,
-    IdPath,
-    EntityIdActivityStreamPagenumPath,
-    _strip_openapi_kwargs,
-)
+from flaskapp.openapi_models import _strip_openapi_kwargs
 
 # RDF format translations
 from flaskapp.graph_prefix_bindings import get_bound_graph, FORMATS
@@ -78,6 +74,15 @@ from flaskapp.conneg import (
     get_data_using_profile_query,
     reformat_rdf,
 )
+
+# For path typing
+from flaskapp.openapi_models import (
+    EntityIdPath,
+    IdPath,
+    EntityIdActivityStreamPagenumPath,
+    _strip_openapi_kwargs,
+)
+
 
 from gettysparqlpatterns import RequiredParametersMissingError
 
@@ -341,7 +346,6 @@ def container_record(container_id, page=None):
     "/<path:entity_id>/",
     tags=[ldp_tag, records_tag],
     summary="Create resource (LDP)",
-    path=EntityIdPath,
     responses={
         201: {"description": "Resource created"},
         400: {"description": "Bad request"},
@@ -351,7 +355,7 @@ def container_record(container_id, page=None):
     strict_slashes=False,
 )
 @records.post("/", defaults={"entity_id": "/"}, strict_slashes=False)
-def container_post_item(entity_id):
+def container_post_item(path: EntityIdPath):
     # Could be a resource or a container being POSTed to a target URI which has to be an existing container
     # Behavior will be as LDP states:
     # - if the target is a Container, and the POSTed item is a valid Resource or Container:
@@ -391,7 +395,7 @@ def container_post_item(entity_id):
     # Get the implied container-hierarchy from the entity_id:
     # eg "/object/1234" --> ["/", "/object/", "/object/1234"]
     # Will always contain "/" as first item, unless the entity_id is "/"
-    container_breadcrumbs = segment_entity_id(entity_id)
+    container_breadcrumbs = segment_entity_id(path.entity_id)
 
     # Valid JSON-LD? Fail if not with a HTTP 422 Wrong Syntax
     try:
@@ -428,11 +432,11 @@ def container_post_item(entity_id):
 
     # Is there a record here?
     current_app.logger.debug(
-        f"Looking up resource {entity_id} in case it is a record not a container"
+        f"Looking up resource {path.entity_id} in case it is a record not a container"
     )
     record = (
         db.session.query(Record)
-        .filter(Record.entity_id == entity_id)
+        .filter(Record.entity_id == path.entity_id)
         .options(defer(Record.data))
         .limit(1)
         .one_or_none()
@@ -599,7 +603,7 @@ def container_post_item(entity_id):
             status_nt(
                 404,
                 "No Resource Found",
-                f"Must POST a resource to a valid ldp:BasicContainer. {entity_id} is not a container",
+                f"Must POST a resource to a valid ldp:BasicContainer. {path.entity_id} is not a container",
             )
         )
         abort(response)
@@ -609,36 +613,35 @@ def container_post_item(entity_id):
     "/<path:entity_id>",
     tags=[records_tag],
     summary="Get record",
-    path=EntityIdPath,
     responses={
         200: {"description": "Record data in requested format"},
         304: {"description": "Not Modified (ETag match)"},
         404: {"description": "Record not found"},
     },
 )
-def entity_record(entity_id):
+def entity_record(path: EntityIdPath):
     """GET the record that exactly matches the entity_id, or if the entity_id ends with a '*', treat it as a wildcard
     search for items in the LOD Gateway"""
     # idPrefix will be used by either the API route returning the record, or the route listing matches
-    if current_app.config["LDP_API"] and entity_id.endswith("/"):
+    if current_app.config["LDP_API"] and path.entity_id.endswith("/"):
         # treat trailing slashes in IDs as containers
-        return container_record(entity_id)
+        return container_record(path.entity_id)
 
     hostPrefix = current_app.config["BASE_URL"]
     idPrefix = current_app.config["idPrefix"]
 
-    current_app.logger.debug(f"{entity_id} - Profiling started 0.0000000")
+    current_app.logger.debug(f"{path.entity_id} - Profiling started 0.0000000")
     profile_time = time.perf_counter()
 
-    if entity_id.endswith("*"):
+    if path.entity_id.endswith("*"):
         ####################
         # Prefix searching #
         ####################
 
         # entity_id ends with a '*'
-        r_json = handle_prefix_listing(entity_id, request, idPrefix)
+        r_json = handle_prefix_listing(path.entity_id, request, idPrefix)
         current_app.logger.debug(
-            f"{entity_id} - Handle prefix listing took {time.perf_counter() - profile_time}"
+            f"{path.entity_id} - Handle prefix listing took {time.perf_counter() - profile_time}"
         )
         return jsonify(r_json)
     else:
@@ -646,17 +649,17 @@ def entity_record(entity_id):
         # Direct record access #
         ########################
 
-        current_app.logger.info(f"Looking up resource {entity_id}")
+        current_app.logger.info(f"Looking up resource {path.entity_id}")
         record = (
             db.session.query(Record)
-            .filter(Record.entity_id == entity_id)
+            .filter(Record.entity_id == path.entity_id)
             .options(defer(Record.data))
             .limit(1)
             .first()
         )
 
         current_app.logger.debug(
-            f"{entity_id} - Record lookup complete at timecode {time.perf_counter() - profile_time}"
+            f"{path.entity_id} - Record lookup complete at timecode {time.perf_counter() - profile_time}"
         )
         # Sub-addressing vars
         subaddressed = None
@@ -664,11 +667,11 @@ def entity_record(entity_id):
 
         if record is None and current_app.config["SUBADDRESSING"] is True:
             current_app.logger.warning(
-                f"{entity_id} not found - attempting subaddress to find a document containing this identifier."
+                f"{path.entity_id} not found - attempting subaddress to find a document containing this identifier."
             )
-            record, subdata = subaddressing_search(entity_id)
+            record, subdata = subaddressing_search(path.entity_id)
             current_app.logger.debug(
-                f"{entity_id} - Subaddressing lookup at {time.perf_counter() - profile_time}"
+                f"{path.entity_id} - Subaddressing lookup at {time.perf_counter() - profile_time}"
             )
             if record is not None:
                 subaddressed = url_for(
@@ -721,10 +724,10 @@ def entity_record(entity_id):
                 )
 
             current_app.logger.debug(
-                f"{entity_id} - Version query run and Link headers generated at timecode {time.perf_counter() - profile_time}"
+                f"{path.entity_id} - Version query run and Link headers generated at timecode {time.perf_counter() - profile_time}"
             )
         else:
-            current_app.logger.debug(f"{entity_id} - Version query run disabled.")
+            current_app.logger.debug(f"{path.entity_id} - Version query run disabled.")
 
         # Is the client trying to negotiate for an earlier version through Accept-Datetime
         if (
@@ -733,7 +736,7 @@ def entity_record(entity_id):
             and "accept-datetime" in request.headers
         ):
             current_app.logger.debug(
-                f"{entity_id} - request for earlier version. Query begun at {time.perf_counter() - profile_time}"
+                f"{path.entity_id} - request for earlier version. Query begun at {time.perf_counter() - profile_time}"
             )
             # parse date and try to find a matching version, 302 redirect
             desired_datetime = dateparser.parse(
@@ -765,7 +768,7 @@ def entity_record(entity_id):
                     abort(response)
 
                 current_app.logger.debug(
-                    f"{entity_id} - Desired version generated at timecode {time.perf_counter() - profile_time}"
+                    f"{path.entity_id} - Desired version generated at timecode {time.perf_counter() - profile_time}"
                 )
                 # found an version predating the version asked for
                 # 302 Redirect to that version.
@@ -785,7 +788,7 @@ def entity_record(entity_id):
         # Otherwise, supply the current record.
         if record and record.data:
             current_app.logger.debug(
-                f"{entity_id} - If-None-Match header set? {bool(request.if_none_match)}"
+                f"{path.entity_id} - If-None-Match header set? {bool(request.if_none_match)}"
             )
             if record.checksum in request.if_none_match:
                 # Client has supplied etags of the resources it has cached for this URI
@@ -840,7 +843,7 @@ def entity_record(entity_id):
                 )  # so pass back the record data as-is to the client
             else:  # otherwise, record "id" field prefixing is enabled, as configured
                 current_app.logger.debug(
-                    f"{entity_id} - PREFIXING IDs to absolute URIs STARTED at timecode {time.perf_counter() - profile_time}"
+                    f"{path.entity_id} - PREFIXING IDs to absolute URIs STARTED at timecode {time.perf_counter() - profile_time}"
                 )
 
                 recursive = (
@@ -881,7 +884,7 @@ def entity_record(entity_id):
                         del data["@context"]
 
                 current_app.logger.debug(
-                    f"{entity_id} - PREFIXING IDs to absolute URIs ENDED at timecode {time.perf_counter() - profile_time}"
+                    f"{path.entity_id} - PREFIXING IDs to absolute URIs ENDED at timecode {time.perf_counter() - profile_time}"
                 )
 
             # data holds a version of the JSON with the FQDN version of the ids
@@ -1017,7 +1020,7 @@ def entity_record(entity_id):
                             ## Reformat the JSON-LD ##
                             # Set the mimetype:
                             current_app.logger.debug(
-                                f"{entity_id} - CHANGING RDFFORMAT STARTED at timecode {time.perf_counter() - profile_time}"
+                                f"{path.entity_id} - CHANGING RDFFORMAT STARTED at timecode {time.perf_counter() - profile_time}"
                             )
                             content_type, q, shortformat = desired[
                                 "accepted_mimetypes"
@@ -1029,7 +1032,7 @@ def entity_record(entity_id):
                             )
                             if use_pyld:
                                 current_app.logger.debug(
-                                    f"{entity_id} - using PyLD to parse JSON-LD"
+                                    f"{path.entity_id} - using PyLD to parse JSON-LD"
                                 )
                                 data = reformat_rdf(
                                     data,
@@ -1041,7 +1044,7 @@ def entity_record(entity_id):
                                 etag = None
                             else:
                                 current_app.logger.debug(
-                                    f"{entity_id} - using RDFLIB to parse JSON-LD"
+                                    f"{path.entity_id} - using RDFLIB to parse JSON-LD"
                                 )
                                 data = reformat_rdf(
                                     data,
@@ -1053,7 +1056,7 @@ def entity_record(entity_id):
                                 etag = None
 
                             current_app.logger.debug(
-                                f"{entity_id} - CHANGING RDFFORMAT FINISHED at timecode {time.perf_counter() - profile_time}"
+                                f"{path.entity_id} - CHANGING RDFFORMAT FINISHED at timecode {time.perf_counter() - profile_time}"
                             )
 
             # Force plaintext?
@@ -1074,7 +1077,7 @@ def entity_record(entity_id):
             if subaddressed is not None:
                 response.headers["Location"] = subaddressed
             current_app.logger.debug(
-                f"{entity_id} - REQUEST COMPLETE at timecode {time.perf_counter() - profile_time}"
+                f"{path.entity_id} - REQUEST COMPLETE at timecode {time.perf_counter() - profile_time}"
             )
             if request.method == "HEAD":
                 # clear the response body as this is just a HEAD request
@@ -1102,14 +1105,13 @@ def entity_record(entity_id):
     "/<path:id>",
     tags=[records_tag],
     summary="Delete record",
-    path=IdPath,
     responses={
         200: {"description": "Deleted successfully"},
         401: {"description": "Unauthorized"},
         404: {"description": "Not found"},
     },
 )
-def delete(id):
+def delete(path: IdPath):
     # Authentication
     status = authenticate_bearer(request, current_app)
     if status != status_ok:
@@ -1119,7 +1121,7 @@ def delete(id):
     current_app.logger.debug("Authentication checked - DELETE request allowed.")
 
     # Get record from DB
-    db_resp = get_record(id)
+    db_resp = get_record(path.id)
 
     # No such record or a stub record
     match db_resp:
@@ -1131,14 +1133,14 @@ def delete(id):
             # Process DELETE
             with db.session.no_autoflush:
                 try:
-                    current_app.logger.debug(f"Starting delete process on {id}")
+                    current_app.logger.debug(f"Starting delete process on {path.id}")
 
                     process_activity(db_rec.id, Event.Delete)
                     record_delete(db_rec, None)
 
                     # Process RDF if applicable
                     if current_app.config["PROCESS_RDF"] is True:
-                        full_uri = f"{current_app.config['RDFidPrefix']}/{id}"
+                        full_uri = f"{current_app.config['RDFidPrefix']}/{path.id}"
                         current_app.logger.debug(
                             f"Attempting to delete {full_uri} from graphstore"
                         )
@@ -1165,7 +1167,7 @@ def delete(id):
                 except exc.OperationalError as e:
                     current_app.logger.error(e)
                     current_app.logger.critical(
-                        f"DB Failure when attempting to delete {id}"
+                        f"DB Failure when attempting to delete {path.id}"
                     )
                     db.session.rollback()
                     abort(construct_error_response(status_db_save_error))
@@ -1214,14 +1216,13 @@ def delete(id):
     "/-VERSION-/<path:entity_id>",
     tags=[timegate_tag, records_tag],
     summary="Get record version",
-    path=EntityIdPath,
     responses={
         200: {"description": "Version data"},
         304: {"description": "Not Modified"},
         404: {"description": "Not found"},
     },
 )
-def entity_version(entity_id):
+def entity_version(path: EntityIdPath):
     # check if versioning authentication required
     status = status_ok
     if current_app.config["VERSION_AUTH"].lower() == "true":
@@ -1231,7 +1232,7 @@ def entity_version(entity_id):
         response = construct_error_response(status)
         abort(response)
 
-    current_app.logger.debug(f"{entity_id} - Profiling started 0.0000000")
+    current_app.logger.debug(f"{path.entity_id} - Profiling started 0.0000000")
     profile_time = time.perf_counter()
 
     if current_app.config["KEEP_LAST_VERSION"] is True:
@@ -1241,7 +1242,7 @@ def entity_version(entity_id):
         hostPrefix = current_app.config["BASE_URL"]
         idPrefix = current_app.config["idPrefix"]
 
-        version = Version.query.filter(Version.entity_id == entity_id).one_or_none()
+        version = Version.query.filter(Version.entity_id == path.entity_id).one_or_none()
 
         if version is not None:
             # There is a record of a version of a resource here. The record is available through version.record
@@ -1289,7 +1290,7 @@ def entity_version(entity_id):
                     allow_format_rewriting = False
                 else:  # otherwise, record "id" field prefixing is enabled, as configured
                     current_app.logger.debug(
-                        f"{entity_id} - PREFIXING IDs to absolute URIs STARTED at timecode {time.perf_counter() - profile_time}"
+                        f"{path.entity_id} - PREFIXING IDs to absolute URIs STARTED at timecode {time.perf_counter() - profile_time}"
                     )
                     recursive = (
                         False if prefixRecordIDs == "TOP" else True
@@ -1311,7 +1312,7 @@ def entity_version(entity_id):
                     )
 
                 current_app.logger.debug(
-                    f"{entity_id} - PREFIXING IDs to absolute URIs ENDED at timecode {time.perf_counter() - profile_time}"
+                    f"{path.entity_id} - PREFIXING IDs to absolute URIs ENDED at timecode {time.perf_counter() - profile_time}"
                 )
 
             content_type = "application/json;charset=UTF-8"
@@ -1330,7 +1331,7 @@ def entity_version(entity_id):
                     if desired[1] != "json-ld":
                         # Set the mimetype:
                         current_app.logger.debug(
-                            f"VERSION {entity_id} - CHANGING RDFFORMAT STARTED at timecode {time.perf_counter() - profile_time}"
+                            f"VERSION {path.entity_id} - CHANGING RDFFORMAT STARTED at timecode {time.perf_counter() - profile_time}"
                         )
                         content_type = desired[0]
                         if "force-plain-text" in request.values:
@@ -1342,7 +1343,7 @@ def entity_version(entity_id):
                             and "rdflib" not in request.values
                         ):
                             current_app.logger.debug(
-                                f"VERSION {entity_id} - using PyLD to parse JSON-LD"
+                                f"VERSION {path.entity_id} - using PyLD to parse JSON-LD"
                             )
                             # Use the PyLD library to parse into nquads, and rdflib to convert
                             # rdflib's json-ld import has not been tested on our data, so not relying on it
@@ -1370,7 +1371,7 @@ def entity_version(entity_id):
                             data = g.serialize(format=desired[1])
                         else:
                             current_app.logger.debug(
-                                f"{entity_id} - using RDFLIB to parse JSON-LD"
+                                f"{path.entity_id} - using RDFLIB to parse JSON-LD"
                             )
                             ident = data.get("id") or data.get("@id")
 
@@ -1381,7 +1382,7 @@ def entity_version(entity_id):
                             data = g.serialize(format=desired[1])
 
                         current_app.logger.debug(
-                            f"VERSION {entity_id} - CHANGING RDFFORMAT FINISHED at timecode {time.perf_counter() - profile_time}"
+                            f"VERSION {path.entity_id} - CHANGING RDFFORMAT FINISHED at timecode {time.perf_counter() - profile_time}"
                         )
 
             response = current_app.make_response(data or "")
@@ -1420,13 +1421,12 @@ def entity_version(entity_id):
     "/-VERSION-/<path:entity_id>",
     tags=[timegate_tag],
     summary="Delete record version",
-    path=EntityIdPath,
     responses={
         200: {"description": "Version deleted"},
         404: {"description": "Not found"},
     },
 )
-def delete_entity_version(entity_id):
+def delete_entity_version(path: EntityIdPath):
     # Authentication. If fails, abort with 401
     status = authenticate_bearer(request, current_app)
     if status != status_ok:
@@ -1436,7 +1436,7 @@ def delete_entity_version(entity_id):
     if current_app.config["KEEP_LAST_VERSION"] is True:
         """GET the version that exactly matches the id supplied"""
 
-        version = Version.query.filter(Version.entity_id == entity_id).one_or_none()
+        version = Version.query.filter(Version.entity_id == path.entity_id).one_or_none()
 
         if version is None:
             response = construct_error_response(status_record_not_found)
@@ -1444,15 +1444,15 @@ def delete_entity_version(entity_id):
 
         try:
             current_app.logger.warning(
-                f"Deleting version '-VERSION-/{entity_id}' as requested."
+                f"Deleting version '-VERSION-/{path.entity_id}' as requested."
             )
             db.session.delete(version)
             db.session.commit()
-            return jsonify({"message": f"-VERSION-/{entity_id} deleted."}), 200
+            return jsonify({"message": f"-VERSION-/{path.entity_id} deleted."}), 200
         except SQLAlchemyError as e:
             db.session.rollback()
             current_app.logger.error(
-                f"Hit an error attempting to delete -VERSION-/{entity_id}"
+                f"Hit an error attempting to delete -VERSION-/{path.entity_id}"
             )
             current_app.logger.error(e)
             response = construct_error_response(status_db_error)
@@ -1466,14 +1466,13 @@ def delete_entity_version(entity_id):
     "/<path:entity_id>/activity-stream",
     tags=[activity_tag],
     summary="Record activity stream",
-    path=EntityIdPath,
     responses={
         200: {"description": "Activity stream"},
         404: {"description": "No activity stream for this record"},
     },
 )
-def entity_record_activity_stream(entity_id):
-    count = get_record_activities_count(entity_id)
+def entity_record_activity_stream(path: EntityIdPath):
+    count = get_record_activities_count(path.entity_id)
     limit = current_app.config["ITEMS_PER_PAGE"]
     total_pages = math.ceil(count / limit)
 
@@ -1488,16 +1487,16 @@ def entity_record_activity_stream(entity_id):
             "@context": "https://www.w3.org/ns/activitystreams",
             "summary": current_app.config["AS_DESC"],
             "type": "OrderedCollection",
-            "id": url_record(entity_id),
+            "id": url_record(path.entity_id),
             "totalItems": count,
         }
 
         data["first"] = {
-            "id": url_record(entity_id, 1),
+            "id": url_record(path.entity_id, 1),
             "type": "OrderedCollectionPage",
         }
         data["last"] = {
-            "id": url_record(entity_id, total_pages),
+            "id": url_record(path.entity_id, total_pages),
             "type": "OrderedCollectionPage",
         }
 
@@ -1508,21 +1507,20 @@ def entity_record_activity_stream(entity_id):
     "/<path:entity_id>/activity-stream",
     tags=[activity_tag],
     summary="Truncate record activity stream",
-    path=EntityIdPath,
     responses={
         200: {"description": "Events removed"},
         400: {"description": "Bad request"},
         401: {"description": "Unauthorized"},
     },
 )
-def truncate_activity_stream_of_entity_id(entity_id):
+def truncate_activity_stream_of_entity_id(path: EntityIdPath):
     # Authentication. If fails, abort with 401
     status = authenticate_bearer(request, current_app)
     if status != status_ok:
         response = construct_error_response(status)
         abort(response)
 
-    count = get_record_activities_count(entity_id)
+    count = get_record_activities_count(path.entity_id)
     # Are there events for this ID?
     if count == 0:
         response = construct_error_response(status_record_not_found)
@@ -1572,7 +1570,7 @@ def truncate_activity_stream_of_entity_id(entity_id):
     # Get the list of events, sorted by id but DESCENDING
     # Should be from newest to oldest event.
     activity_list = (
-        Activity.query.filter(Activity.record.has(entity_id=entity_id))
+        Activity.query.filter(Activity.record.has(entity_id=path.entity_id))
         .order_by(Activity.id.desc())
         .all()
     )
@@ -1585,7 +1583,7 @@ def truncate_activity_stream_of_entity_id(entity_id):
         deleted += 1
 
     current_app.logger.warning(
-        f"Truncating {entity_id} activity-stream to most recent {keep_latest_events} event(s)"
+        f"Truncating {path.entity_id} activity-stream to most recent {keep_latest_events} event(s)"
     )
     try:
         db.session.commit()
@@ -1597,23 +1595,21 @@ def truncate_activity_stream_of_entity_id(entity_id):
 
 
 @records.get(
-    "/<path:entity_id>/activity-stream/page/<string:pagenum>",
+    "/<path:entity_id>/activity-stream/page/<int:pagenum>",
     tags=[activity_tag],
     summary="Record activity stream page",
-    path=EntityIdActivityStreamPagenumPath,
     responses={
         200: {"description": "Paginated activity items"},
         404: {"description": "Page out of bounds"},
     },
 )
-@records.get("/<path:entity_id>/activity-stream/page/<string:pagenum>")
-def record_activity_stream_page(entity_id, pagenum):
-    count = get_record_activities_count(entity_id)
-    pagenum = int(pagenum)
+def record_activity_stream_page(path: EntityIdActivityStreamPagenumPath):
+    count = get_record_activities_count(path.entity_id)
+    pagenum = int(path.pagenum)
     limit = current_app.config["ITEMS_PER_PAGE"]
     offset = (pagenum - 1) * limit
     total_pages = math.ceil(count / limit)
-    activities = get_record_activities(entity_id, offset, limit)
+    activities = get_record_activities(path.entity_id, offset, limit)
 
     if pagenum == 0 or pagenum > total_pages:
         response = construct_error_response(status_page_not_found)
@@ -1622,19 +1618,19 @@ def record_activity_stream_page(entity_id, pagenum):
     data = {
         "@context": "https://www.w3.org/ns/activitystreams",
         "type": "OrderedCollectionPage",
-        "id": url_record(entity_id, pagenum),
-        "partOf": {"id": url_record(entity_id), "type": "OrderedCollection"},
+        "id": url_record(path.entity_id, pagenum),
+        "partOf": {"id": url_record(path.entity_id), "type": "OrderedCollection"},
     }
 
     if pagenum < total_pages:
         data["next"] = {
-            "id": url_record(entity_id, pagenum + 1),
+            "id": url_record(path.entity_id, pagenum + 1),
             "type": "OrderedCollectionPage",
         }
 
     if pagenum > 1:
         data["prev"] = {
-            "id": url_record(entity_id, pagenum - 1),
+            "id": url_record(path.entity_id, pagenum - 1),
             "type": "OrderedCollectionPage",
         }
 

--- a/source/web-service/flaskapp/routes/records.py
+++ b/source/web-service/flaskapp/routes/records.py
@@ -1,5 +1,4 @@
 import click
-from typing import Optional
 import math
 import json
 
@@ -620,8 +619,90 @@ def container_post_item(
     "/<path:entity_id>",
     tags=[records_tag],
     summary="Get record",
+    description="Retrieve a record by entity ID. Supports RDF content negotiation via Accept header or 'format' query parameter. Returns the record in the requested format (JSON-LD, Turtle, N-Triples, N-Quads, N3, or TRIG).",
     responses={
-        200: {"description": "Record data in requested format"},
+        200: {
+            "description": "Record data in requested format",
+            "content": {
+                "application/ld+json": {
+                    "schema": {
+                        "type": "object",
+                        "description": "JSON-LD representation of the record with expanded context and prefixed URIs.",
+                    },
+                    "examples": {
+                        "json-ld": {
+                            "summary": "JSON-LD format",
+                            "value": {
+                                "@context": "https://www.w3.org/ns/ontology-web-syntax",
+                                "@id": "https://example.org/entity/123",
+                                "type": "Thing",
+                                "name": "Example Entity",
+                            },
+                        }
+                    },
+                },
+                "application/n-triples": {
+                    "schema": {
+                        "type": "string",
+                        "description": "N-Triples format - a simple line-based RDF serialization with one triple per line.",
+                    },
+                    "examples": {
+                        "nt": {
+                            "summary": "N-Triples format",
+                            "value": "<https://example.org/entity/123> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Thing> .\n",
+                        }
+                    },
+                },
+                "text/turtle": {
+                    "schema": {
+                        "type": "string",
+                        "description": "Turtle format - a more compact RDF serialization that groups triples by subject.",
+                    },
+                    "examples": {
+                        "turtle": {
+                            "summary": "Turtle format",
+                            "value": "@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix ex: <https://example.org/entity/123> .\nex: a rdf:Thing .\n",
+                        }
+                    },
+                },
+                "application/n-quads": {
+                    "schema": {
+                        "type": "string",
+                        "description": "N-Quads format - N-Triples with an additional quad graph name per line.",
+                    },
+                    "examples": {
+                        "nquads": {
+                            "summary": "N-Quads format",
+                            "value": "<https://example.org/entity/123> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Thing> <https://example.org/graph> .\n",
+                        }
+                    },
+                },
+                "text/n3": {
+                    "schema": {
+                        "type": "string",
+                        "description": "N3 format - a more expressive RDF serialization with support for named graphs and negation.",
+                    },
+                    "examples": {
+                        "n3": {
+                            "summary": "N3 format",
+                            "value": "@prefix ex: <https://example.org/entity/123> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\nex: a rdf:Thing .\n",
+                        }
+                    },
+                },
+                "application/trig": {
+                    "schema": {
+                        "type": "string",
+                        "description": "TRIG format - Turtle with support for named graphs.",
+                    },
+                    "examples": {
+                        "trig": {
+                            "summary": "TRIG format",
+                            "value": "@prefix ex: <https://example.org/entity/123> .\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\n{\n  ex: a rdf:Thing .\n} .\n",
+                        }
+                    },
+                },
+            },
+        },
         304: {"description": "Not Modified (ETag match)"},
         404: {"description": "Record not found"},
     },

--- a/source/web-service/flaskapp/routes/records.py
+++ b/source/web-service/flaskapp/routes/records.py
@@ -1242,7 +1242,9 @@ def entity_version(path: EntityIdPath):
         hostPrefix = current_app.config["BASE_URL"]
         idPrefix = current_app.config["idPrefix"]
 
-        version = Version.query.filter(Version.entity_id == path.entity_id).one_or_none()
+        version = Version.query.filter(
+            Version.entity_id == path.entity_id
+        ).one_or_none()
 
         if version is not None:
             # There is a record of a version of a resource here. The record is available through version.record
@@ -1436,7 +1438,9 @@ def delete_entity_version(path: EntityIdPath):
     if current_app.config["KEEP_LAST_VERSION"] is True:
         """GET the version that exactly matches the id supplied"""
 
-        version = Version.query.filter(Version.entity_id == path.entity_id).one_or_none()
+        version = Version.query.filter(
+            Version.entity_id == path.entity_id
+        ).one_or_none()
 
         if version is None:
             response = construct_error_response(status_record_not_found)

--- a/source/web-service/flaskapp/routes/records.py
+++ b/source/web-service/flaskapp/routes/records.py
@@ -9,7 +9,8 @@ import time
 
 from email.utils import formatdate
 
-from flask import Blueprint, current_app, abort, request, jsonify, url_for, redirect
+from flask_openapi3 import APIBlueprint
+from flask import current_app, abort, request, jsonify, url_for, redirect
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.orm import load_only, defer
 from sqlalchemy import func, exc
@@ -61,6 +62,7 @@ from flaskapp.errors import (
 )
 from flaskapp.utilities import checksum_json, authenticate_bearer, squish_dict
 from flaskapp.base_graph_utils import get_url_prefixes_from_context
+from flaskapp.openapi import records_tag, ldp_tag, timegate_tag, activity_tag
 
 # RDF format translations
 from flaskapp.graph_prefix_bindings import get_bound_graph, FORMATS
@@ -76,7 +78,34 @@ from gettysparqlpatterns import RequiredParametersMissingError
 from pyld import jsonld
 
 # Create a new "records" route blueprint
-records = Blueprint("records", __name__)
+records = APIBlueprint("records", __name__)
+
+_OPENAPI_KWARGS = frozenset(
+    [
+        "tags",
+        "summary",
+        "responses",
+        "description",
+        "security",
+        "deprecated",
+        "external_docs",
+        "servers",
+        "operation_id",
+        "openapi_extensions",
+    ]
+)
+
+
+_original_records_add_url_rule = records.add_url_rule
+
+
+def _records_add_url_rule(*args, **kwargs):
+    for key in _OPENAPI_KWARGS:
+        kwargs.pop(key, None)
+    _original_records_add_url_rule(*args, **kwargs)
+
+
+records.add_url_rule = _records_add_url_rule
 
 trueset = {"true", "t", "y"}
 
@@ -328,8 +357,21 @@ def container_record(container_id, page=None):
         )
 
 
-@records.route("/<path:entity_id>/", methods=["POST"])
-@records.route("/", methods=["POST"], defaults={"entity_id": "/"})
+@records.post(
+    "/<path:entity_id>/",
+    tags=[ldp_tag, records_tag],
+    summary="Create resource (LDP)",
+    responses={
+        201: {"description": "Resource created"},
+        400: {"description": "Bad request"},
+        401: {"description": "Unauthorized"},
+        409: {"description": "Conflict"},
+    },
+)
+@records.post(
+    "/",
+    defaults={"entity_id": "/"},
+)
 def container_post_item(entity_id):
     # Could be a resource or a container being POSTed to a target URI which has to be an existing container
     # Behavior will be as LDP states:
@@ -584,7 +626,16 @@ def container_post_item(entity_id):
         abort(response)
 
 
-@records.route("/<path:entity_id>", methods=["GET", "HEAD", "OPTIONS"])
+@records.get(
+    "/<path:entity_id>",
+    tags=[records_tag],
+    summary="Get record",
+    responses={
+        200: {"description": "Record data in requested format"},
+        304: {"description": "Not Modified (ETag match)"},
+        404: {"description": "Record not found"},
+    },
+)
 def entity_record(entity_id):
     """GET the record that exactly matches the entity_id, or if the entity_id ends with a '*', treat it as a wildcard
     search for items in the LOD Gateway"""
@@ -1067,7 +1118,16 @@ def entity_record(entity_id):
 
 
 # 'DELETE' method.
-@records.route("/<path:id>", methods=["DELETE"])
+@records.delete(
+    "/<path:id>",
+    tags=[records_tag],
+    summary="Delete record",
+    responses={
+        200: {"description": "Deleted successfully"},
+        401: {"description": "Unauthorized"},
+        404: {"description": "Not found"},
+    },
+)
 def delete(id):
     # Authentication
     status = authenticate_bearer(request, current_app)
@@ -1169,7 +1229,16 @@ def delete(id):
 
 
 # old version of a record
-@records.route("/-VERSION-/<path:entity_id>", methods=["GET", "HEAD"])
+@records.get(
+    "/-VERSION-/<path:entity_id>",
+    tags=[timegate_tag, records_tag],
+    summary="Get record version",
+    responses={
+        200: {"description": "Version data"},
+        304: {"description": "Not Modified"},
+        404: {"description": "Not found"},
+    },
+)
 def entity_version(entity_id):
     # check if versioning authentication required
     status = status_ok
@@ -1366,7 +1435,15 @@ def entity_version(entity_id):
 
 
 # old version of a record
-@records.route("/-VERSION-/<path:entity_id>", methods=["DELETE"])
+@records.delete(
+    "/-VERSION-/<path:entity_id>",
+    tags=[timegate_tag],
+    summary="Delete record version",
+    responses={
+        200: {"description": "Version deleted"},
+        404: {"description": "Not found"},
+    },
+)
 def delete_entity_version(entity_id):
     # Authentication. If fails, abort with 401
     status = authenticate_bearer(request, current_app)
@@ -1403,7 +1480,15 @@ def delete_entity_version(entity_id):
 ### Activity Stream of the record ###
 
 
-@records.route("/<path:entity_id>/activity-stream", methods=["GET", "HEAD"])
+@records.get(
+    "/<path:entity_id>/activity-stream",
+    tags=[activity_tag],
+    summary="Record activity stream",
+    responses={
+        200: {"description": "Activity stream"},
+        404: {"description": "No activity stream for this record"},
+    },
+)
 def entity_record_activity_stream(entity_id):
     count = get_record_activities_count(entity_id)
     limit = current_app.config["ITEMS_PER_PAGE"]
@@ -1436,7 +1521,16 @@ def entity_record_activity_stream(entity_id):
     return current_app.make_response(data)
 
 
-@records.route("/<path:entity_id>/activity-stream", methods=["POST"])
+@records.post(
+    "/<path:entity_id>/activity-stream",
+    tags=[activity_tag],
+    summary="Truncate record activity stream",
+    responses={
+        200: {"description": "Events removed"},
+        400: {"description": "Bad request"},
+        401: {"description": "Unauthorized"},
+    },
+)
 def truncate_activity_stream_of_entity_id(entity_id):
     # Authentication. If fails, abort with 401
     status = authenticate_bearer(request, current_app)
@@ -1518,7 +1612,16 @@ def truncate_activity_stream_of_entity_id(entity_id):
         raise e
 
 
-@records.route("/<path:entity_id>/activity-stream/page/<string:pagenum>")
+@records.get(
+    "/<path:entity_id>/activity-stream/page/<string:pagenum>",
+    tags=[activity_tag],
+    summary="Record activity stream page",
+    responses={
+        200: {"description": "Paginated activity items"},
+        404: {"description": "Page out of bounds"},
+    },
+)
+@records.get("/<path:entity_id>/activity-stream/page/<string:pagenum>")
 def record_activity_stream_page(entity_id, pagenum):
     count = get_record_activities_count(entity_id)
     pagenum = int(pagenum)

--- a/source/web-service/flaskapp/routes/records.py
+++ b/source/web-service/flaskapp/routes/records.py
@@ -1104,7 +1104,7 @@ def entity_record(path: EntityIdPath):
 
 # 'DELETE' method.
 @records.delete(
-    "/<path:id>",
+    "/<path:entity_id>",
     tags=[records_tag],
     summary="Delete record",
     description="Permanently delete a record by entity ID. Requires Bearer token authentication.",
@@ -1115,7 +1115,7 @@ def entity_record(path: EntityIdPath):
         404: {"description": "Not found"},
     },
 )
-def delete(path: IdPath):
+def delete(path: EntityIdPath):
     # Authentication
     status = authenticate_bearer(request, current_app)
     if status != status_ok:

--- a/source/web-service/flaskapp/routes/records.py
+++ b/source/web-service/flaskapp/routes/records.py
@@ -64,7 +64,14 @@ from flaskapp.errors import (
 from flaskapp.utilities import checksum_json, authenticate_bearer, squish_dict
 from flaskapp.base_graph_utils import get_url_prefixes_from_context
 from flaskapp.openapi import records_tag, ldp_tag, timegate_tag, activity_tag
-from flaskapp.openapi_models import _strip_openapi_kwargs
+
+# For path typing
+from flaskapp.openapi_models import (
+    EntityIdPath,
+    EntityBody,
+    EntityIdActivityStreamPagenumPath,
+    _strip_openapi_kwargs,
+)
 
 # RDF format translations
 from flaskapp.graph_prefix_bindings import get_bound_graph, FORMATS
@@ -73,13 +80,6 @@ from flaskapp.conneg import (
     determine_requested_format_and_profile,
     get_data_using_profile_query,
     reformat_rdf,
-)
-
-# For path typing
-from flaskapp.openapi_models import (
-    EntityIdPath,
-    EntityIdActivityStreamPagenumPath,
-    _strip_openapi_kwargs,
 )
 
 
@@ -356,7 +356,7 @@ def container_record(container_id, page=None):
     strict_slashes=False,
 )
 @records.post("/", defaults={"entity_id": "/"}, strict_slashes=False)
-def container_post_item(path: EntityIdPath):
+def container_post_item(path: EntityIdPath, body: EntityBody):
     # Could be a resource or a container being POSTed to a target URI which has to be an existing container
     # Behavior will be as LDP states:
     # - if the target is a Container, and the POSTed item is a valid Resource or Container:
@@ -404,6 +404,7 @@ def container_post_item(path: EntityIdPath):
             f'{current_app.config["idPrefix"]}/',
             container_breadcrumbs[-1].strip("/"),
             request,
+            EntityBody,
         )
         current_app.logger.info(
             f"POSTed JSON parsed as JSON-LD and rebased to: {posted_representation.has_top_level_id()}"

--- a/source/web-service/flaskapp/routes/records.py
+++ b/source/web-service/flaskapp/routes/records.py
@@ -70,6 +70,7 @@ from flaskapp.openapi_models import (
     EntityIdPath,
     EntityBody,
     PlainBody,
+    OptionalSlugQuery,
     EntityIdActivityStreamPagenumPath,
     _strip_openapi_kwargs,
 )
@@ -357,7 +358,9 @@ def container_record(container_id, page=None):
     strict_slashes=False,
 )
 @records.post("/", defaults={"entity_id": "/"}, strict_slashes=False)
-def container_post_item(path: EntityIdPath, body: PlainBody):
+def container_post_item(
+    path: EntityIdPath, body: PlainBody, query: OptionalSlugQuery = None
+):
     # Could be a resource or a container being POSTed to a target URI which has to be an existing container
     # Behavior will be as LDP states:
     # - if the target is a Container, and the POSTed item is a valid Resource or Container:
@@ -406,6 +409,7 @@ def container_post_item(path: EntityIdPath, body: PlainBody):
             container_breadcrumbs[-1].strip("/"),
             request,
             body,
+            query,
         )
         current_app.logger.info(
             f"POSTed JSON parsed as JSON-LD and rebased to: {posted_representation.has_top_level_id()}"

--- a/source/web-service/flaskapp/routes/records.py
+++ b/source/web-service/flaskapp/routes/records.py
@@ -78,7 +78,6 @@ from flaskapp.conneg import (
 # For path typing
 from flaskapp.openapi_models import (
     EntityIdPath,
-    IdPath,
     EntityIdActivityStreamPagenumPath,
     _strip_openapi_kwargs,
 )
@@ -1125,7 +1124,7 @@ def delete(path: EntityIdPath):
     current_app.logger.debug("Authentication checked - DELETE request allowed.")
 
     # Get record from DB
-    db_resp = get_record(path.id)
+    db_resp = get_record(path.entity_id)
 
     # No such record or a stub record
     match db_resp:
@@ -1137,14 +1136,18 @@ def delete(path: EntityIdPath):
             # Process DELETE
             with db.session.no_autoflush:
                 try:
-                    current_app.logger.debug(f"Starting delete process on {path.id}")
+                    current_app.logger.debug(
+                        f"Starting delete process on {path.entity_id}"
+                    )
 
                     process_activity(db_rec.id, Event.Delete)
                     record_delete(db_rec, None)
 
                     # Process RDF if applicable
                     if current_app.config["PROCESS_RDF"] is True:
-                        full_uri = f"{current_app.config['RDFidPrefix']}/{path.id}"
+                        full_uri = (
+                            f"{current_app.config['RDFidPrefix']}/{path.entity_id}"
+                        )
                         current_app.logger.debug(
                             f"Attempting to delete {full_uri} from graphstore"
                         )
@@ -1171,7 +1174,7 @@ def delete(path: EntityIdPath):
                 except exc.OperationalError as e:
                     current_app.logger.error(e)
                     current_app.logger.critical(
-                        f"DB Failure when attempting to delete {path.id}"
+                        f"DB Failure when attempting to delete {path.entity_id}"
                     )
                     db.session.rollback()
                     abort(construct_error_response(status_db_save_error))
@@ -1210,7 +1213,7 @@ def delete(path: EntityIdPath):
                     )
                     abort(response)
         case None:
-            current_app.logger.error(f"No such resource at {id}")
+            current_app.logger.error(f"No such resource at {path.entity_id}")
             response = construct_error_response(status_record_not_found)
             abort(response)
 

--- a/source/web-service/flaskapp/routes/sparql.py
+++ b/source/web-service/flaskapp/routes/sparql.py
@@ -12,6 +12,7 @@ from flaskapp.errors import (
 )
 
 from flaskapp.openapi import sparql_tag
+from flaskapp.openapi_models import _strip_openapi_kwargs
 
 from flaskapp.utilities import (
     authenticate_bearer,
@@ -21,33 +22,7 @@ from flaskapp.utilities import (
 
 # Create a new "sparql" route blueprint
 sparql = APIBlueprint("sparql", __name__)
-
-_OPENAPI_KWARGS = frozenset(
-    [
-        "tags",
-        "summary",
-        "responses",
-        "description",
-        "security",
-        "deprecated",
-        "external_docs",
-        "servers",
-        "operation_id",
-        "openapi_extensions",
-    ]
-)
-
-
-_original_sparql_add_url_rule = sparql.add_url_rule
-
-
-def _sparql_add_url_rule(*args, **kwargs):
-    for key in _OPENAPI_KWARGS:
-        kwargs.pop(key, None)
-    _original_sparql_add_url_rule(*args, **kwargs)
-
-
-sparql.add_url_rule = _sparql_add_url_rule
+_strip_openapi_kwargs(sparql)
 
 
 # ### ROUTES ###

--- a/source/web-service/flaskapp/routes/sparql.py
+++ b/source/web-service/flaskapp/routes/sparql.py
@@ -30,6 +30,8 @@ _strip_openapi_kwargs(sparql)
     "/sparql",
     tags=[sparql_tag],
     summary="SPARQL query endpoint",
+    description="Execute a SPARQL query. Authentication is required if SPARQL_QUERY_AUTHENTICATION is set to true (default: false).",
+    security=[{"bearerAuth": []}, {}],
     responses={
         200: {"description": "SPARQL results"},
         400: {"description": "Bad request"},
@@ -41,6 +43,8 @@ _strip_openapi_kwargs(sparql)
     "/sparql",
     tags=[sparql_tag],
     summary="SPARQL query endpoint",
+    description="Execute a SPARQL query (POST variant). Authentication is required if SPARQL_QUERY_AUTHENTICATION is set to true (default: false).",
+    security=[{"bearerAuth": []}, {}],
     responses={
         200: {"description": "SPARQL results"},
         400: {"description": "Bad request"},

--- a/source/web-service/flaskapp/routes/sparql.py
+++ b/source/web-service/flaskapp/routes/sparql.py
@@ -1,14 +1,8 @@
 import time
 import requests
 
-from flask import (
-    Blueprint,
-    current_app,
-    request,
-    abort,
-    Response,
-    make_response,
-)
+from flask_openapi3 import APIBlueprint
+from flask import current_app, request, abort, Response, make_response
 
 from flaskapp.errors import (
     status_nt,
@@ -17,13 +11,62 @@ from flaskapp.errors import (
 )
 
 from flaskapp.utilities import execute_sparql_query_post, execute_sparql_query
+from flaskapp.openapi import sparql_tag
 
 # Create a new "sparql" route blueprint
-sparql = Blueprint("sparql", __name__)
+sparql = APIBlueprint("sparql", __name__)
+
+_OPENAPI_KWARGS = frozenset(
+    [
+        "tags",
+        "summary",
+        "responses",
+        "description",
+        "security",
+        "deprecated",
+        "external_docs",
+        "servers",
+        "operation_id",
+        "openapi_extensions",
+    ]
+)
+
+
+_original_sparql_add_url_rule = sparql.add_url_rule
+
+
+def _sparql_add_url_rule(*args, **kwargs):
+    for key in _OPENAPI_KWARGS:
+        kwargs.pop(key, None)
+    _original_sparql_add_url_rule(*args, **kwargs)
+
+
+sparql.add_url_rule = _sparql_add_url_rule
 
 
 # ### ROUTES ###
-@sparql.route("/sparql", methods=["GET", "POST"])
+@sparql.get(
+    "/sparql",
+    tags=[sparql_tag],
+    summary="SPARQL query endpoint",
+    responses={
+        200: {"description": "SPARQL results"},
+        400: {"description": "Bad request"},
+        501: {"description": "RDF not enabled"},
+        504: {"description": "Query timeout"},
+    },
+)
+@sparql.post(
+    "/sparql",
+    tags=[sparql_tag],
+    summary="SPARQL query endpoint",
+    responses={
+        200: {"description": "SPARQL results"},
+        400: {"description": "Bad request"},
+        501: {"description": "RDF not enabled"},
+        504: {"description": "Query timeout"},
+    },
+)
 def query_entrypoint():
     if current_app.config["PROCESS_RDF"] is not True:
         response = construct_error_response(

--- a/source/web-service/flaskapp/routes/timegate.py
+++ b/source/web-service/flaskapp/routes/timegate.py
@@ -1,6 +1,7 @@
 from email.utils import formatdate
 
-from flask import Blueprint, current_app, abort, request, jsonify, url_for
+from flask_openapi3 import APIBlueprint
+from flask import current_app, abort, request, jsonify, url_for
 from sqlalchemy.orm import load_only
 
 from flaskapp.models import db
@@ -10,9 +11,37 @@ from flaskapp.errors import (
     construct_error_response,
     status_record_not_found,
 )
+from flaskapp.openapi import timegate_tag
 
 # Create a new "sparql" route blueprint
-timegate = Blueprint("timegate", __name__)
+timegate = APIBlueprint("timegate", __name__)
+
+_OPENAPI_KWARGS = frozenset(
+    [
+        "tags",
+        "summary",
+        "responses",
+        "description",
+        "security",
+        "deprecated",
+        "external_docs",
+        "servers",
+        "operation_id",
+        "openapi_extensions",
+    ]
+)
+
+
+_original_timegate_add_url_rule = timegate.add_url_rule
+
+
+def _timegate_add_url_rule(*args, **kwargs):
+    for key in _OPENAPI_KWARGS:
+        kwargs.pop(key, None)
+    _original_timegate_add_url_rule(*args, **kwargs)
+
+
+timegate.add_url_rule = _timegate_add_url_rule
 
 
 def json_to_linkformat(d):
@@ -21,7 +50,15 @@ def json_to_linkformat(d):
     return ";".join(lf)
 
 
-@timegate.route("/-tm-/<path:entity_id>")
+@timegate.get(
+    "/-tm-/<path:entity_id>",
+    tags=[timegate_tag],
+    summary="Get timemap (Memento)",
+    responses={
+        200: {"description": "Timemap in requested format"},
+        404: {"description": "Entity not found"},
+    },
+)
 def get_timemap(entity_id):
     # Get the timemap for the given entity_id, if one exists
     idPrefix = current_app.config["BASE_URL"]

--- a/source/web-service/flaskapp/routes/timegate.py
+++ b/source/web-service/flaskapp/routes/timegate.py
@@ -12,36 +12,11 @@ from flaskapp.errors import (
     status_record_not_found,
 )
 from flaskapp.openapi import timegate_tag
+from flaskapp.openapi_models import EntityIdPath, _strip_openapi_kwargs
 
 # Create a new "sparql" route blueprint
 timegate = APIBlueprint("timegate", __name__)
-
-_OPENAPI_KWARGS = frozenset(
-    [
-        "tags",
-        "summary",
-        "responses",
-        "description",
-        "security",
-        "deprecated",
-        "external_docs",
-        "servers",
-        "operation_id",
-        "openapi_extensions",
-    ]
-)
-
-
-_original_timegate_add_url_rule = timegate.add_url_rule
-
-
-def _timegate_add_url_rule(*args, **kwargs):
-    for key in _OPENAPI_KWARGS:
-        kwargs.pop(key, None)
-    _original_timegate_add_url_rule(*args, **kwargs)
-
-
-timegate.add_url_rule = _timegate_add_url_rule
+_strip_openapi_kwargs(timegate)
 
 
 def json_to_linkformat(d):
@@ -54,6 +29,7 @@ def json_to_linkformat(d):
     "/-tm-/<path:entity_id>",
     tags=[timegate_tag],
     summary="Get timemap (Memento)",
+    path=EntityIdPath,
     responses={
         200: {"description": "Timemap in requested format"},
         404: {"description": "Entity not found"},

--- a/source/web-service/flaskapp/routes/yasgui.py
+++ b/source/web-service/flaskapp/routes/yasgui.py
@@ -1,12 +1,49 @@
-from flask import Blueprint, current_app, abort
+from flask_openapi3 import APIBlueprint
+from flask import current_app, abort
 from flaskapp.errors import status_nt, construct_error_response
+from flaskapp.openapi import sparql_tag
 
 # Create a new "yasgui" route blueprint
-yasgui = Blueprint("yasgui", __name__)
+yasgui = APIBlueprint("yasgui", __name__)
+
+_OPENAPI_KWARGS = frozenset(
+    [
+        "tags",
+        "summary",
+        "responses",
+        "description",
+        "security",
+        "deprecated",
+        "external_docs",
+        "servers",
+        "operation_id",
+        "openapi_extensions",
+    ]
+)
+
+
+_original_yasgui_add_url_rule = yasgui.add_url_rule
+
+
+def _yasgui_add_url_rule(*args, **kwargs):
+    for key in _OPENAPI_KWARGS:
+        kwargs.pop(key, None)
+    _original_yasgui_add_url_rule(*args, **kwargs)
+
+
+yasgui.add_url_rule = _yasgui_add_url_rule
 
 
 # ### ROUTES ###
-@yasgui.route("/sparql-ui", methods=["GET"])
+@yasgui.get(
+    "/sparql-ui",
+    tags=[sparql_tag],
+    summary="SPARQL UI page",
+    responses={
+        200: {"description": "HTML page"},
+        501: {"description": "RDF not enabled"},
+    },
+)
 def get_yasgui():
     if current_app.config["PROCESS_RDF"] is not True:
         response = construct_error_response(

--- a/source/web-service/flaskapp/routes/yasgui.py
+++ b/source/web-service/flaskapp/routes/yasgui.py
@@ -15,6 +15,8 @@ _strip_openapi_kwargs(yasgui)
     "/sparql-ui",
     tags=[sparql_tag],
     summary="SPARQL UI page",
+    description="Serve the YASGUI SPARQL query interface. Authentication is required if SPARQL_QUERY_AUTHENTICATION is set to true (default: false).",
+    security=[{"bearerAuth": []}, {}],
     responses={
         200: {"description": "HTML page"},
         501: {"description": "RDF not enabled"},

--- a/source/web-service/flaskapp/routes/yasgui.py
+++ b/source/web-service/flaskapp/routes/yasgui.py
@@ -2,37 +2,12 @@ from flask_openapi3 import APIBlueprint
 from flask import current_app, abort, request
 from flaskapp.errors import status_nt, construct_error_response, status_ok
 from flaskapp.openapi import sparql_tag
+from flaskapp.openapi_models import _strip_openapi_kwargs
 from flaskapp.utilities import authenticate_bearer
 
 # Create a new "yasgui" route blueprint
 yasgui = APIBlueprint("yasgui", __name__)
-
-_OPENAPI_KWARGS = frozenset(
-    [
-        "tags",
-        "summary",
-        "responses",
-        "description",
-        "security",
-        "deprecated",
-        "external_docs",
-        "servers",
-        "operation_id",
-        "openapi_extensions",
-    ]
-)
-
-
-_original_yasgui_add_url_rule = yasgui.add_url_rule
-
-
-def _yasgui_add_url_rule(*args, **kwargs):
-    for key in _OPENAPI_KWARGS:
-        kwargs.pop(key, None)
-    _original_yasgui_add_url_rule(*args, **kwargs)
-
-
-yasgui.add_url_rule = _yasgui_add_url_rule
+_strip_openapi_kwargs(yasgui)
 
 
 # ### ROUTES ###

--- a/source/web-service/flaskapp/storage_utilities/representation.py
+++ b/source/web-service/flaskapp/storage_utilities/representation.py
@@ -244,13 +244,19 @@ class Representation:
                         self._description = _get_value(v)
 
 
-def parse_representation(server_root, relative_container, request, entitybody):
+def parse_representation(
+    server_root, relative_container, request, entitybody, query_params
+):
     # check for valid JSON-LD
     # rebase, and return Representation
     # capture the Slug header if present, even though the rebase does not take that into account yet.
     if request.headers["Content-Type"] == "application/ld+json":
         # Slug?
         slug = request.headers.get("Slug") or None
+
+        if query_params and query_params.slug:
+            slug = query_params.slug
+
         r = Representation(
             server_root=server_root, relative_container=relative_container, slug=slug
         )

--- a/source/web-service/flaskapp/storage_utilities/representation.py
+++ b/source/web-service/flaskapp/storage_utilities/representation.py
@@ -244,7 +244,7 @@ class Representation:
                         self._description = _get_value(v)
 
 
-def parse_representation(server_root, relative_container, request):
+def parse_representation(server_root, relative_container, request, entitybody):
     # check for valid JSON-LD
     # rebase, and return Representation
     # capture the Slug header if present, even though the rebase does not take that into account yet.
@@ -254,7 +254,8 @@ def parse_representation(server_root, relative_container, request):
         r = Representation(
             server_root=server_root, relative_container=relative_container, slug=slug
         )
-        r.json_ld = request.get_json()
+        r.json_ld = entitybody.model_dump()
+
         return r
     else:
         raise ResourceValidationError(

--- a/source/web-service/pyproject.toml
+++ b/source/web-service/pyproject.toml
@@ -9,6 +9,30 @@ testpaths = [
     "tests"
 ]
 
+[project]
+name = "lod-gateway"
+version = "1.0.0"
+requires-python = ">=3.10"
+dependencies = [
+    "Flask>=3.1.0,<4.0",
+    "Flask-Cors>=5.0.0,<6.0",
+    "Flask-Migrate>=4.1.0,<5.0",
+    "Flask-SQLAlchemy>=3.1.0,<4.0",
+    "SQLAlchemy>=2.0.40,<3.0",
+    "flask-openapi3[swagger]>=4.3.0,<5.0",
+    "requests>=2.32",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.3.0,<9.0",
+    "pytest-cov>=3.0.0,<4.0",
+    "pytest-flask>=1.3.0,<2.0",
+    "pytest-mock>=3.14.0,<4.0",
+    "black>=26.0.0,<27.0",
+]
+
+
 [tool.black]
 line-length = 88
 target-version = ['py310']

--- a/source/web-service/tests/test_routes_activity.py
+++ b/source/web-service/tests/test_routes_activity.py
@@ -338,7 +338,7 @@ class TestPageRoute:
     def test_page_zero(self, client, test_db, namespace):
         url = f"/{namespace}/activity-stream/page/0"
         response = client.get(url)
-        assert response.status_code == 404
+        assert response.status_code == 422
 
     def test_format_datetime(self):
         dt = datetime(2019, 11, 22, 13, 2, 53)


### PR DESCRIPTION
Flask-OpenAPI3 looks like the best way to join the route declarations and a publishable OpenAPI spec for the service. Other libraries require a separate swagger.json file that has to be kept in sync with the code, often manually, whereas this way registers the routes as part of the API and generates the OpenAPI spec from that.

The OpenAPI3 library essentially shims between Flask and Blueprints, and we use OpenAPI (overlay of Flask) and APIBlueprints (overlay of Blueprints). The second element is Pydantic, it gets used for declaring the inputs and outputs and things don't work well otherwise. I have added a patch so that we can still use path kwargs freely, but the pydantic way is to have a path object, and to pull typed parameters from that. 

The route decorator holds a lot of information about the API endpoint right next to it, which hopefully might encourage us to keep it in line with what the thing does...

eg 

```
@records.post(
    "/<path:entity_id>/",
    tags=[ldp_tag, records_tag],
    summary="Create resource (LDP)",
    responses={
        201: {"description": "Resource created"},
        400: {"description": "Bad request"},
        401: {"description": "Unauthorized"},
        409: {"description": "Conflict"},
    },
    strict_slashes=False,
)
@records.post("/", defaults={"entity_id": "/"}, strict_slashes=False)
def container_post_item(path: EntityIdPath):
...

```

Note that typed path variable - the type is important and necessary, and that class is defined using Pydantic elsewhere. To get the entity_id out of it, you would use `path.entity_id` which is a change. The patch I added means that you should still be able to put in say `def container_post_item(entity_id)` and it will work, but we should push towards the pydantic way if we go this way.

## What does this give us?

We get a new endpoint /openapi which provides our openapi.json but mainly it gives us a cool little API page with all the endpoints and their 'try me' functionality. [I still need to work out the best way to incorporate authentication for some of the commands, but it's possible]